### PR TITLE
feat: Spring Security적용 및 JWT 필터, Access/Refresh Token생성 인터페이스 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# 🏗️ 계층별 역할 및 책임 가이드 (Architecture Guidelines)
+
+각 계층은 **철저한 관심사의 분리** 를 원칙으로 하며, 의존성은 항상 **외부에서 내부(Domain)** 로 향해야 합니다.
+
+### 📋 한눈에 보는 요약표
+
+| 계층 (Layer) | 핵심 역할 (Core Responsibility) | 주요 키워드 (Keywords) |
+| :--- | :--- | :--- |
+| **Presentation** | 외부 요청 처리 및 응답 반환 | `Controller`, `Web Adapter`, `DTO` |
+| **Application** | 비즈니스 흐름 제어 및 트랜잭션 관리 | `UseCase`, `Service`, `Transaction` |
+| **Domain** | 핵심 비즈니스 규칙 및 엔티티 상태 변경 | `Entity`, `VO`, `Domain Service` |
+| **Infrastructure** | 기술적 구현 및 외부 시스템 연동 | `RepositoryImpl`, `JPA`, `Redis`, `Client` |
+
+---
+
+## 1. 🌐 Presentation Layer (표현 계층)
+> **사용자의 요청을 받아 Application 계층으로 전달하고, 결과를 사용자에게 반환합니다.**
+
+### ✅ 역할 (Responsibility)
+- **API 엔드포인트:** REST API 요청을 받는 진입점 (`Controller`)
+- **데이터 변환:** HTTP 요청(`Request Body`)을 Application 전용 `DTO`로 변환
+- **응답 처리:** 처리 결과를 클라이언트가 이해할 수 있는 포맷(`Response DTO`, `HTTP Status`)으로 반환
+- **보안:** 기본적인 인증/인가 필터링 및 외부 어댑터 역할
+
+### 🚫 금지 (Restriction)
+- **비즈니스 로직 포함 금지:** 순수한 전달자 역할만 수행해야 합니다.
+- **`Entity` 노출 금지:** 클라이언트에게 도메인 `Entity`를 직접 반환하면 안 됩니다.
+- **DB 직접 접근 금지:** `Repository`를 직접 호출하지 않습니다.
+
+---
+
+## 2. ⚙️ Application Layer (응용 계층)
+> **도메인 객체와 인프라 자원을 조율하여 애플리케이션의 유스케이스를 실행합니다.**
+
+### ✅ 역할 (Responsibility)
+- **유스케이스(UseCase) 처리:** 구체적인 사용자 요구사항(기능) 구현
+- **흐름 제어:** 도메인 객체를 가져오고(`Repository`), 로직을 실행하고(`Domain`), 저장하는 흐름 관리
+- **트랜잭션 관리:** `@Transactional` 등을 통한 데이터 일관성 보장
+- **입력값 검증:** 유효성 검사 수행
+- **인터페이스 사용:** `Infrastructure`의 구현체를 직접 의존하지 않고 인터페이스를 통해 호출
+
+### 🚫 금지 (Restriction)
+- **비즈니스 판단 로직 금지:** "상태가 A면 B로 바꾼다"는 규칙은 `Domain`에 있어야 합니다. 여기서는 순서만 제어합니다.
+- **기술 종속성 배제:** `HttpServletRequest`, `JWT`, `Redis` 등 구체적인 기술 관련 코드가 섞이면 안 됩니다. (POJO 지향)
+- **SQL/Infra 코드 금지:** 데이터베이스 쿼리나 외부 API 호출 코드를 직접 작성하지 않습니다.
+
+---
+
+## 3. 🧠 Domain Layer (도메인 계층)
+> **소프트웨어의 심장부로, 가장 변하지 않는 핵심 비즈니스 규칙을 담습니다.**
+
+### ✅ 역할 (Responsibility)
+- **핵심 모델 정의:** `Entity`, `Value Object(VO)`, `Aggregate` 정의
+- **비즈니스 규칙 구현:** 엔티티 스스로 상태를 변경하는 메서드 (예: `user.activate()`)
+- **도메인 서비스:** 엔티티만으로 처리하기 힘든 도메인 규칙 정의 (인터페이스 주도)
+- **추상화된 인터페이스 제공:** 외부 기술이 필요한 기능(저장소, 암호화 등)을 위한 인터페이스 정의 (예: `UserRepository`, `JwtProvider`)
+
+### 🚫 금지 (Restriction)
+- **기술 의존성 제로(0):** 프레임워크(`Spring`), DB, UI 등 외부 기술에 대한 코드가 단 한 줄도 없어야 합니다.
+- **외부 호출 금지:** `DB` 접근이나 외부 `API` 호출을 직접 수행하지 않습니다.
+
+---
+
+## 4. 🔌 Infrastructure Layer (인프라 계층)
+> **도메인과 애플리케이션 계층에서 정의한 인터페이스를 실제 기술로 구현합니다.**
+
+### ✅ 역할 (Responsibility)
+- **기술 구현체:** `JPA`, `MyBatis`, `Redis` 등을 활용한 Repository 인터페이스 구현
+- **외부 시스템 연동:** 외부 API(`Kakao`, `Apple`), 결제 시스템(`PG`) 호출 구현
+- **기반 기술 지원:** `JWT` 발급 구현체(`JwtProviderImpl`), 파일 저장(`S3`) 등
+- **어댑터:** 애플리케이션이 필요로 하는 기술적 기능을 실제로 동작하게 만듦
+
+### 🚫 금지 (Restriction)
+- **비즈니스 규칙 포함 금지:** 기술적인 동작만 담당해야 하며, 비즈니스 판단을 내려서는 안 됩니다.
+- **도메인 오염 주의:** 구현체가 도메인 모델을 침범하거나 변경해서는 안 됩니다.
+- **`Presentation` 참조 금지:** 컨트롤러 등을 역으로 참조하면 안 됩니다.
+
+---
+
+### 💡 핵심: 의존성 규칙 (Dependency Rule)
+모든 소스 코드의 의존성은 반드시 **외부에서 내부**로 향해야 합니다.
+
+- `Infrastructure` ➡️ `Application` ➡️ `Domain` (⭕)
+- `Domain` ➡️ `Infrastructure` (❌ 절대 금지)
+
+이 원칙을 지키기 위해 **DIP(의존성 역전 원칙)** 를 사용하여, `Domain`은 인터페이스를 정의하고 `Infrastructure`가 이를 구현(`Implements`)합니다.

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/joojoo/api/ApiResponse.java
+++ b/src/main/java/com/joojoo/api/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.joojoo.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ApiResponse<T> {
+
+    private int code;
+    private HttpStatus status;
+    private String message;
+    private T data;
+
+    public ApiResponse(HttpStatus status, String message, T data) {
+        this.code = status.value();
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
+        return new ApiResponse<>(httpStatus, message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, T data) {
+        return of(httpStatus, httpStatus.name(), data);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return of(HttpStatus.OK, data);
+    }
+}

--- a/src/main/java/com/joojoo/api/jwt/domain/model/entity/Tokens.java
+++ b/src/main/java/com/joojoo/api/jwt/domain/model/entity/Tokens.java
@@ -1,0 +1,34 @@
+package com.joojoo.api.jwt.domain.model.entity;
+
+import com.joojoo.api.user.domain.model.entity.Users;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "tokens")
+public class Tokens {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long tokenId;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/joojoo/api/jwt/domain/service/JwtProvider.java
+++ b/src/main/java/com/joojoo/api/jwt/domain/service/JwtProvider.java
@@ -1,0 +1,18 @@
+package com.joojoo.api.jwt.domain.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.Authentication;
+
+public interface JwtProvider {
+    String createAccessToken(Long userId, String userName);
+    String createRefreshToken(Long userId, String userName);
+
+    // 해더에서 토큰 추출
+    String extractBearerToken(HttpServletRequest request);
+    // 토큰 유효성 검사
+    void validateToken(String token);
+    // 토큰에서 인증 정보 조회
+    Authentication getAuthentication(String token);
+    // 로그아웃 구현 시 필요: 토큰의 남은 유효시간(ms) 조회
+    Long getExpiration(String token);
+}

--- a/src/main/java/com/joojoo/api/jwt/infrastructure/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/joojoo/api/jwt/infrastructure/jwt/JwtProviderImpl.java
@@ -1,0 +1,100 @@
+package com.joojoo.api.jwt.infrastructure.jwt;
+
+import com.joojoo.api.jwt.domain.service.JwtProvider;
+import com.joojoo.api.user.domain.model.custom.CustomUserDetails;
+import io.jsonwebtoken.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
+@Component
+public class JwtProviderImpl implements JwtProvider {
+
+    @Value("${JWT_SECRET}")
+    private String secretKey;
+
+    @Value("${JWT_ACCESS_EXPIRATION}")
+    private long accessTokenValidity;
+
+    @Value("${JWT_REFRESH_EXPIRATION}")
+    private long refreshTokenValidity;
+
+    @Override
+    public String createAccessToken(Long userId, String userName) {
+        Claims claims = Jwts.claims().setSubject(userName);
+        claims.put("userId", userId);
+        return createToken(claims, accessTokenValidity);
+    }
+
+    @Override
+    public String createRefreshToken(Long userId, String userName) {
+        Claims claims = Jwts.claims().setSubject(userName);
+        claims.put("userId", userId);
+        return createToken(claims, refreshTokenValidity);
+    }
+
+    private String createToken(Claims claims, long validity) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + validity);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    @Override
+    public String extractBearerToken(HttpServletRequest request) { // Authorization 헤더에서 Bearer 토큰을 추출
+        String bearer = request.getHeader("Authorization");
+        return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
+    }
+
+    @Override
+    public void validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new JwtException("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    @Override
+    public Authentication getAuthentication(String token) { // 토큰에서 User 정보를 꺼내서 Authentication 타입으로 반환
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+
+        String username = claims.getSubject();
+        Long userId = Long.valueOf(claims.get("userId").toString());
+
+        CustomUserDetails principal = new CustomUserDetails(userId, username);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", List.of());
+    }
+
+    @Override
+    public Long getExpiration(String token) {
+        // 토큰의 만료 시간 - 현재 시간 = 남은 시간
+        Date expiration = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        return expiration.getTime() - new Date().getTime();
+    }
+
+}

--- a/src/main/java/com/joojoo/api/user/domain/model/custom/CustomUserDetails.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/custom/CustomUserDetails.java
@@ -1,0 +1,36 @@
+package com.joojoo.api.user.domain.model.custom;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private Long userId;
+    private String userName;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return userName;
+    }
+
+}

--- a/src/main/java/com/joojoo/api/user/domain/model/entity/Users.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/entity/Users.java
@@ -1,0 +1,56 @@
+package com.joojoo.api.user.domain.model.entity;
+
+import com.joojoo.api.jwt.domain.model.entity.Tokens;
+import com.joojoo.api.user.domain.model.enums.Provider;
+import com.joojoo.api.user.domain.model.enums.Status;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "users")
+public class Users {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(length = 50)
+    private String name;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Column(name = "social_refresh")
+    private String socialRefresh;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    private Tokens tokens;
+}

--- a/src/main/java/com/joojoo/api/user/domain/model/enums/Provider.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/enums/Provider.java
@@ -1,0 +1,15 @@
+package com.joojoo.api.user.domain.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Provider {
+
+    KAKAO("Kakao"),
+    APPLE("apple"),
+    ;
+
+    private final String text;
+}

--- a/src/main/java/com/joojoo/api/user/domain/model/enums/Status.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/enums/Status.java
@@ -1,0 +1,15 @@
+package com.joojoo.api.user.domain.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Status {
+
+    ACTIVE("활동"),
+    DELETED("탈퇴"),
+    ;
+
+    private final String text;
+}

--- a/src/main/java/com/joojoo/global/config/CorsConfig.java
+++ b/src/main/java/com/joojoo/global/config/CorsConfig.java
@@ -1,0 +1,27 @@
+package com.joojoo.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5173"));
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/com/joojoo/global/config/SecurityConfig.java
+++ b/src/main/java/com/joojoo/global/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.joojoo.global.config;
+
+import com.joojoo.api.jwt.domain.service.JwtProvider;
+import com.joojoo.global.exception.authentication.CustomAuthenticationEntryPoint;
+import com.joojoo.global.jwt.filter.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final CorsConfigurationSource corsConfigurationSource;
+    private final JwtProvider jwtProvider;
+
+    public SecurityConfig(CorsConfigurationSource corsConfigurationSource, JwtProvider jwtProvider) {
+        this.corsConfigurationSource = corsConfigurationSource;
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtProvider);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/index", "/kakao/login", "/refresh", "/apple/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+
+                .exceptionHandling(ex -> ex
+                        // Security 에서 걸린 애들 즉, authenticated()에 로그인을 안한 애들은 예외처리
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                )
+
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+        ;
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/joojoo/global/exception/authentication/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/joojoo/global/exception/authentication/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.joojoo.global.exception.authentication;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, String> responseBody = new HashMap<>();
+        responseBody.put("error", "로그인을 하지 않으면 접근이 불가능합니다.");
+
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+    }
+
+}

--- a/src/main/java/com/joojoo/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/joojoo/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,83 @@
+package com.joojoo.global.jwt.filter;
+
+import com.joojoo.api.ApiResponse;
+import com.joojoo.api.jwt.domain.service.JwtProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    private final List<String> excludedUrls = List.of( // 인증 제외 URL
+            "/index", "/kakao/login", "/refresh", "/apple/login"
+    );
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("================ doFilterInternal Action ================");
+        log.info("request.getRequestURI() = {}", request.getRequestURI());
+
+        try{
+            if (isExcludedUrl(request)) { // 필터 제외 URL이면 바로 다음 필터로 진행
+                filterChain.doFilter(request, response);
+                return;
+            }
+            authenticateIfTokenExists(request); // JWT 인증 처리 후 SecurityContext에 User정보 저장
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(response, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
+        } catch (JwtException e) {
+            setErrorResponse(response, HttpStatus.UNAUTHORIZED, e.getMessage());
+        } catch (Exception e) {
+            log.error("Unknown error in JwtAuthenticationFilter", e);
+            setErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류 발생");
+        }
+    }
+
+    // JWT 토큰이 있을 경우 인증 처리
+    private void authenticateIfTokenExists(HttpServletRequest request) {
+        String token = jwtProvider.extractBearerToken(request);
+        if (token == null) return;
+
+        jwtProvider.validateToken(token);
+        Authentication auth = jwtProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    // 인증 제외 URL인지 검증
+    private boolean isExcludedUrl(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return excludedUrls.contains(path);
+    }
+
+    private void setErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<Object> apiResponse = ApiResponse.of(status, message);
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(apiResponse);
+
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,3 +4,9 @@ spring:
 
 server:
   port: 8080
+
+  datasource:
+    url: "${DB_URL}"
+    username: "${DB_NAME}"
+    password: "${DB_PWD}"
+    driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
- 도메인 레이어에 `JwtProvider` 인터페이스 추가
  - 애플리케이션 서비스가 JWT 기술 구현을 알지 않도록 추상화
  - `Access/Refresh` 토큰 생성 및 검증 기능 정의

- 인프라 레이어에 JwtProviderImpl 구현
  - JJWT 기반 HS256 서명 알고리즘 적용
  - `createAccessToken()`, `createRefreshToken()` 구현
  - `validateToken()`, `extractBearerToken()` 등 실제 기술 로직 포함
  - `secretKey`, `expiration` 값 환경변수 에서 주입받도록 구성

- `Application` 서비스는 `JwtProvider` 인터페이스만 의존하도록 구조 개선
  - JWT 구현 세부사항 제거
  - 도메인 규칙(토큰 발급 요청)과 기술 구현(JWT 생성) 완전 분리

- DDD & 헥사고날 아키텍처 적용
  - Domain: 규칙/의사결정 중심, 기술 독립
  - Application: 유스케이스 흐름 관리
  - Infrastructure: JWT 구현 세부사항 담당

- 계층분리 이해하기 쉽게 README 작성