### PR TITLE
feat: Redis ZSet 기반 주식 종목 검색 및 자동완성 기능 구현

### DIFF
--- a/src/main/java/com/joojoo/api/jwt/infrastructure/redis/TokenBlacklistRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/jwt/infrastructure/redis/TokenBlacklistRepositoryImpl.java
@@ -1,12 +1,17 @@
 package com.joojoo.api.jwt.infrastructure.redis;
 
 import com.joojoo.api.jwt.domain.repository.TokenBlacklistRepository;
+import com.joojoo.global.exception.handleException.redis.RedisConnectionFailException;
+import jakarta.persistence.QueryTimeoutException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class TokenBlacklistRepositoryImpl implements TokenBlacklistRepository {
@@ -15,15 +20,26 @@ public class TokenBlacklistRepositoryImpl implements TokenBlacklistRepository {
 
     @Override
     public void add(String accessToken, Long expiration) {
-        if (expiration > 0) {
+        if (expiration <= 0) return;
+
+        try {
             redisTemplate.opsForValue()
                     .set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+        } catch (RedisConnectionFailureException | QueryTimeoutException e) {
+            log.error("Redis 연결 실패 또는 타임아웃 발생: {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("Redis 알 수 없는 에러: {}", e.getMessage());
         }
     }
 
     @Override
     public boolean isBlacklisted(String token) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(token));
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(token));
+        } catch (Exception e) {
+            log.warn("Redis 연결 실패 {}", e.getMessage());
+            throw new RedisConnectionFailException();
+        }
     }
 
 }

--- a/src/main/java/com/joojoo/api/ticker/application/TickerService.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerService.java
@@ -1,0 +1,9 @@
+package com.joojoo.api.ticker.application;
+
+import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;
+
+public interface TickerService {
+    void addStockToRedis(String name, String ticker);
+
+    TickerSearchResponse search(String query);
+}

--- a/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
@@ -1,0 +1,44 @@
+package com.joojoo.api.ticker.application;
+
+import com.joojoo.api.ticker.domain.repository.TickerRedisRepository;
+import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;
+import com.joojoo.global.exception.handleException.tickers.InvalidTickerOrNameException;
+import com.joojoo.global.util.HangulUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.Limit;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class TickerServiceImpl implements TickerService {
+
+    private final TickerRedisRepository tickerRedisRepository;
+
+    @Override
+    public void addStockToRedis(String name, String ticker) {
+        if (!StringUtils.hasText(name) || !StringUtils.hasText(ticker)) {
+            throw new InvalidTickerOrNameException();
+        }
+        Set<String> tickers = new HashSet<>();
+        tickers.add(HangulUtils.splitToJaso(name) + "*" + name + "*" + ticker);
+        tickers.add(HangulUtils.getChosung(name) + "*" + name + "*" + ticker);
+
+        tickerRedisRepository.addStocksToRedis(tickers);
+    }
+
+    @Override
+    public TickerSearchResponse search(String query) {
+        if (!StringUtils.hasText(query)) return TickerSearchResponse.of(Collections.emptySet());
+        String convertedQuery = HangulUtils.splitToJaso(query); // query를 자모로 분해 해서 검색
+
+        // Range.rightOpen는 [start, end]를 의미함 convertedQuery으로 시작하는 글자와 convertedQuery뒤에 붙는 글자를 찾는다
+        Range<String> range = Range.rightOpen(convertedQuery, convertedQuery + "\uffff");
+        return TickerSearchResponse.of(tickerRedisRepository.searchTickerQuery(range, Limit.limit().count(10)));
+    }
+}

--- a/src/main/java/com/joojoo/api/ticker/domain/repository/TickerRedisRepository.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/repository/TickerRedisRepository.java
@@ -1,0 +1,14 @@
+package com.joojoo.api.ticker.domain.repository;
+
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.Limit;
+
+import java.util.Set;
+
+public interface TickerRedisRepository {
+    // Redis ZSet 자료구조에 주식 이름 저장 
+    void addStocksToRedis(Set<String> values);
+    
+    // Redis ZSet 자료구조에서 관련 검색어 찾기
+    Set<String> searchTickerQuery(Range<String> range, Limit limit);
+}

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/redis/TickerRedisRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/redis/TickerRedisRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.joojoo.api.ticker.infrastructure.redis;
+
+import com.joojoo.api.ticker.domain.repository.TickerRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class TickerRedisRepositoryImpl implements TickerRedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String AUTOCOMPLETE_KEY = "autocomplete:stock";
+
+    @Override
+    public void addStocksToRedis(Set<String> values) {
+        Set<ZSetOperations.TypedTuple<String>> tuples = new HashSet<>(); // TypedTuple이 value 와 score를 하나의 객체로 묶어줌
+        for (String value : values) {
+            tuples.add(ZSetOperations.TypedTuple.of(value, 0.0));
+        }
+
+        redisTemplate.opsForZSet().add(AUTOCOMPLETE_KEY, tuples);
+    }
+
+    @Override
+    public Set<String> searchTickerQuery(Range<String> range, Limit limit) {
+        return redisTemplate.opsForZSet()
+                .rangeByLex(AUTOCOMPLETE_KEY, range, limit);
+    }
+}

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/redis/TickerRedisRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/redis/TickerRedisRepositoryImpl.java
@@ -1,16 +1,22 @@
 package com.joojoo.api.ticker.infrastructure.redis;
 
 import com.joojoo.api.ticker.domain.repository.TickerRedisRepository;
+import com.joojoo.global.exception.handleException.redis.RedisConnectionFailException;
+import jakarta.persistence.QueryTimeoutException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Range;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class TickerRedisRepositoryImpl implements TickerRedisRepository {
@@ -24,13 +30,25 @@ public class TickerRedisRepositoryImpl implements TickerRedisRepository {
         for (String value : values) {
             tuples.add(ZSetOperations.TypedTuple.of(value, 0.0));
         }
-
-        redisTemplate.opsForZSet().add(AUTOCOMPLETE_KEY, tuples);
+        try {
+            redisTemplate.opsForZSet().add(AUTOCOMPLETE_KEY, tuples);
+        } catch (Exception e) {
+            throw new RedisConnectionFailException();
+        }
     }
 
     @Override
     public Set<String> searchTickerQuery(Range<String> range, Limit limit) {
-        return redisTemplate.opsForZSet()
-                .rangeByLex(AUTOCOMPLETE_KEY, range, limit);
+        try {
+            return redisTemplate.opsForZSet()
+                    .rangeByLex(AUTOCOMPLETE_KEY, range, limit);
+        } catch (RedisConnectionFailureException | QueryTimeoutException e) {
+            log.error("Redis 연결 실패 또는 타임아웃 발생: {}", e.getMessage());
+            return Collections.emptySet();
+        } catch (Exception e) {
+            log.error("Redis 알 수 없는 에러: {}", e.getMessage());
+            return Collections.emptySet();
+        }
     }
+
 }

--- a/src/main/java/com/joojoo/api/ticker/presentation/TickerController.java
+++ b/src/main/java/com/joojoo/api/ticker/presentation/TickerController.java
@@ -3,26 +3,51 @@ package com.joojoo.api.ticker.presentation;
 import com.joojoo.api.ticker.application.TickerService;
 import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;
 import com.joojoo.global.common.response.BaseResponse;
+import com.joojoo.global.common.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/ticker")
+@Tag(name = "Ticker API", description = "주식 티커 관련 API")
 public class TickerController {
     private final TickerService tickerService;
 
-    // 테스트용 API: /add?name=삼성전자&ticker=005930
-    @PostMapping("/add")
-    public BaseResponse<String> addStock(@RequestParam String name, @RequestParam String ticker) {
+
+    @Operation(summary = "주식 티커 추가 (검색 확인용)", description = "Redis에 새로운 주식 이름과 티커 심볼을 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
+            @ApiResponse(responseCode = "401", description = "티커 또는 이름을 작성하세요.",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    @PostMapping("/add") // 테스트용 API: /add?name=삼성전자&ticker=005930
+    public BaseResponse<String> addStock(
+            @Parameter(description = "주식 종목명 (예: 삼성전자)", required = true)
+            @RequestParam String name,
+            @Parameter(description = "주식 티커 (예: 005930)", required = true)
+            @RequestParam String ticker
+    ) {
         tickerService.addStockToRedis(name, ticker);
         return BaseResponse.ok(name + " (" + ticker + ") 저장 성공!");
     }
 
+    @Operation(summary = "티커 검색", description = "쿼리를 통해 저장된 주식 티커를 검색합니다.")
     @GetMapping("/search")
-    public BaseResponse<TickerSearchResponse> searchStock(@RequestParam String query) {
+    public BaseResponse<TickerSearchResponse> searchStock(
+            @Parameter(description = "검색어 (종목명)", required = true)
+            @RequestParam String query
+    ) {
         return BaseResponse.ok(tickerService.search(query));
     }
 }

--- a/src/main/java/com/joojoo/api/ticker/presentation/TickerController.java
+++ b/src/main/java/com/joojoo/api/ticker/presentation/TickerController.java
@@ -1,0 +1,28 @@
+package com.joojoo.api.ticker.presentation;
+
+import com.joojoo.api.ticker.application.TickerService;
+import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;
+import com.joojoo.global.common.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TickerController {
+    private final TickerService tickerService;
+
+    // 테스트용 API: /add?name=삼성전자&ticker=005930
+    @PostMapping("/add")
+    public BaseResponse<String> addStock(@RequestParam String name, @RequestParam String ticker) {
+        tickerService.addStockToRedis(name, ticker);
+        return BaseResponse.ok(name + " (" + ticker + ") 저장 성공!");
+    }
+
+    @GetMapping("/search")
+    public BaseResponse<TickerSearchResponse> searchStock(@RequestParam String query) {
+        return BaseResponse.ok(tickerService.search(query));
+    }
+}

--- a/src/main/java/com/joojoo/api/ticker/presentation/dto/response/TickerSearchResponse.java
+++ b/src/main/java/com/joojoo/api/ticker/presentation/dto/response/TickerSearchResponse.java
@@ -1,0 +1,49 @@
+package com.joojoo.api.ticker.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class TickerSearchResponse {
+    private List<TickerSearchList> tickers;
+
+    @Getter
+    @AllArgsConstructor
+    public static class TickerSearchList {
+        private String name;
+        private String ticker;
+    }
+
+    public static TickerSearchResponse of(Set<String> redisResults) {
+        List<TickerSearchList> searchList = new ArrayList<>(redisResults.stream()
+                .map(TickerSearchResponse::parseRedisData)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(
+                        TickerSearchList::getTicker,
+                        dto -> dto,
+                        (oldValue, newValue) -> oldValue
+                ))
+                .values()
+        );
+
+        return TickerSearchResponse.builder()
+                .tickers(searchList)
+                .build();
+    }
+
+    private static TickerSearchList parseRedisData(String value) {
+        String[] parts = value.split("\\*");
+        if (parts.length < 3) return null; // 잘못 된 형식은 패스
+        return new TickerSearchList(parts[1], parts[2]);
+    }
+
+}

--- a/src/main/java/com/joojoo/global/config/SecurityConfig.java
+++ b/src/main/java/com/joojoo/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource))
 
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/user/kakao/login", "/user/apple/login", "/add").permitAll()
+                .requestMatchers("/user/kakao/login", "/user/apple/login", "/ticker/add").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                 .requestMatchers("/health/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/joojoo/global/config/SecurityConfig.java
+++ b/src/main/java/com/joojoo/global/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.joojoo.global.config;
 
-import com.joojoo.api.jwt.domain.service.JwtProvider;
 import com.joojoo.api.jwt.domain.repository.TokenBlacklistRepository;
+import com.joojoo.api.jwt.domain.service.JwtProvider;
 import com.joojoo.global.exception.authentication.CustomAuthenticationEntryPoint;
 import com.joojoo.global.jwt.filter.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
@@ -40,7 +40,7 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource))
 
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/user/kakao/login", "/user/apple/login").permitAll()
+                .requestMatchers("/user/kakao/login", "/user/apple/login", "/add").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                 .requestMatchers("/health/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -36,6 +36,10 @@ public enum ErrorCode {
     APPLE_TOKEN_ISSUE_FAILED(502, "APPLE_TOKEN_ISSUE_FAILED", "애플 토큰 발급 서버에 문제가 발생했습니다."),
     APPLE_INVALID_TOKEN_RESPONSE(400, "APPLE_INVALID_TOKEN_RESPONSE", "애플 토큰 발급 응답이 올바르지 않습니다."),
     APPLE_INVALID_ID_TOKEN(400, "APPLE_INVALID_ID_TOKEN", "애플 ID Token 형식이 올바르지 않거나 파싱에 실패했습니다."),
+
+    // ---------------------------- 소셜로그인 (Apple) ----------------------------
+    INVALID_TICKER_NAME(401, "INVALID_TICKER_NAME", "티커 또는 이름을 작성하세요."),
+
     ;
 
     private final int httpStatus;

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INVALID_TOKEN(422, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     EXPIRED_ACCESS_TOKEN(401, "EXPIRED_ACCESS_TOKEN", "Access 토큰이 만료되었습니다."),
     EXPIRED_REFRESH_TOKEN(401, "EXPIRED_REFRESH_TOKEN", "Refresh 토큰이 만료되었습니다."),
+    REDIS_CONNECTION_FAIL(401, "REDIS_CONNECTION_FAIL", "Redis 연결에 실패하였습니다."),
 
     // ───────────────────────────── 회원(users) ─────────────────────────────
     USER_NOT_FOUND(404, "USER_NOT_FOUND", "회원을 찾을 수 없습니다."),
@@ -37,7 +38,7 @@ public enum ErrorCode {
     APPLE_INVALID_TOKEN_RESPONSE(400, "APPLE_INVALID_TOKEN_RESPONSE", "애플 토큰 발급 응답이 올바르지 않습니다."),
     APPLE_INVALID_ID_TOKEN(400, "APPLE_INVALID_ID_TOKEN", "애플 ID Token 형식이 올바르지 않거나 파싱에 실패했습니다."),
 
-    // ---------------------------- 소셜로그인 (Apple) ----------------------------
+    // ---------------------------- 티커 (Ticker) ----------------------------
     INVALID_TICKER_NAME(401, "INVALID_TICKER_NAME", "티커 또는 이름을 작성하세요."),
 
     ;

--- a/src/main/java/com/joojoo/global/exception/handleException/redis/RedisConnectionFailException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/redis/RedisConnectionFailException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.redis;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class RedisConnectionFailException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.REDIS_CONNECTION_FAIL;
+
+    public RedisConnectionFailException() {
+        super(errorCode);
+    }
+
+    public RedisConnectionFailException(Exception exception) {
+        super(errorCode, exception);
+    }
+}

--- a/src/main/java/com/joojoo/global/exception/handleException/tickers/InvalidTickerOrNameException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/tickers/InvalidTickerOrNameException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.tickers;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class InvalidTickerOrNameException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.INVALID_TICKER_NAME;
+
+    public InvalidTickerOrNameException() {
+        super(errorCode);
+    }
+
+    public InvalidTickerOrNameException(Exception exception) {
+        super(errorCode, exception);
+    }
+}

--- a/src/main/java/com/joojoo/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/joojoo/global/jwt/filter/JwtAuthenticationFilter.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.joojoo.api.jwt.domain.repository.TokenBlacklistRepository;
 import com.joojoo.api.jwt.domain.service.JwtProvider;
 import com.joojoo.global.common.response.BaseResponse;
+import com.joojoo.global.common.response.ErrorResponse;
+import com.joojoo.global.exception.handleException.redis.RedisConnectionFailException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -26,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenBlacklistRepository tokenBlacklistRepository;
 
     private final List<String> excludedUrls = List.of( // 인증 제외 URL
-        "/user/kakao/login", "/user/apple/login", "/add"
+        "/user/kakao/login", "/user/apple/login", "/ticker/add"
     );
 
     public JwtAuthenticationFilter(JwtProvider jwtProvider, TokenBlacklistRepository tokenBlacklistRepository) {
@@ -50,6 +52,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             setErrorResponse(response, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
         } catch (JwtException e) {
             setErrorResponse(response, HttpStatus.UNAUTHORIZED, e.getMessage());
+        } catch (RedisConnectionFailException e) {
+            log.error("Redis 장애 발생");
+            setErrorResponse(response, HttpStatus.SERVICE_UNAVAILABLE, "시스템 Redis가 접속 불량이여 점검 중입니다.");
         } catch (Exception e) {
             log.error("Unknown error in JwtAuthenticationFilter", e);
             setErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류 발생");
@@ -81,9 +86,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
-        BaseResponse<Object> baseResponse = BaseResponse.of(status, message);
+        // BaseResponse -> ErrorResponse 로 교체
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(status.value())
+                .message(message)           // 예: "시스템 점검 중입니다 (Redis)."
+                .code(status.name())        // 예: "SERVICE_UNAVAILABLE" (HTTP 상태 이름을 코드로 사용)
+                .detailMessage(message)     // 상세 메시지도 동일하게 넣음
+                .build();
+
         ObjectMapper mapper = new ObjectMapper();
-        String json = mapper.writeValueAsString(baseResponse);
+        String json = mapper.writeValueAsString(errorResponse);
 
         response.getWriter().write(json);
     }

--- a/src/main/java/com/joojoo/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/joojoo/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,8 +1,9 @@
 package com.joojoo.global.jwt.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.joojoo.api.jwt.domain.repository.TokenBlacklistRepository;
-import com.joojoo.global.common.response.BaseResponse;
 import com.joojoo.api.jwt.domain.service.JwtProvider;
+import com.joojoo.global.common.response.BaseResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -14,7 +15,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenBlacklistRepository tokenBlacklistRepository;
 
     private final List<String> excludedUrls = List.of( // 인증 제외 URL
-        "/user/kakao/login", "/user/apple/login"
+        "/user/kakao/login", "/user/apple/login", "/add"
     );
 
     public JwtAuthenticationFilter(JwtProvider jwtProvider, TokenBlacklistRepository tokenBlacklistRepository) {

--- a/src/main/java/com/joojoo/global/util/HangulUtils.java
+++ b/src/main/java/com/joojoo/global/util/HangulUtils.java
@@ -1,0 +1,69 @@
+package com.joojoo.global.util;
+
+public class HangulUtils {
+
+    // 초성 (19개)
+    private static final char[] CHOSUNG = {
+            'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ',
+            'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+    };
+    // 중성 (21개)
+    private static final char[] JUNGSUNG = {
+            'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ',
+            'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ'
+    };
+    // 종성 (28개)
+    private static final char[] JONGSUNG = {
+            '\0', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ',
+            'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ',
+            'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+    };
+
+    /**
+     * 문자열을 자모 단위로 완전 분해 (검색 & 저장용)
+     * 예: "테슬라" -> "ㅌㅔㅅㅡㄹㄹㅏ"
+     */
+    public static String splitToJaso(String text) {
+        if (text == null) return null;
+
+        StringBuilder sb = new StringBuilder();
+        for (char ch : text.toCharArray()) {
+            if (ch >= 0xAC00 && ch <= 0xD7A3) { // 한글인 경우
+                int uniVal = ch - 0xAC00;
+                int cho = uniVal / (21 * 28);
+                int jung = (uniVal % (21 * 28)) / 28;
+                int jong = uniVal % 28;
+
+                sb.append(CHOSUNG[cho]);
+                sb.append(JUNGSUNG[jung]);
+                if (jong > 0) {
+                    sb.append(JONGSUNG[jong]);
+                }
+            } else {
+                sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 초성만 추출 (저장용) - [수정] 내용 채워넣음!
+     * 예: "테슬라" -> "ㅌㅅㄹ"
+     */
+    public static String getChosung(String text) {
+        if (text == null) return null;
+
+        StringBuilder sb = new StringBuilder();
+        for (char ch : text.toCharArray()) {
+            if (ch >= 0xAC00 && ch <= 0xD7A3) {
+                int uniVal = ch - 0xAC00;
+                int cho = uniVal / (21 * 28);
+                sb.append(CHOSUNG[cho]); // 초성만 append
+            } else {
+                sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] Redis ZSet 기반 주식 종목 검색 및 자동완성 기능 구현

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [ ] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

Redis의 **Sorted Set(ZSet)** 자료구조와 `rangeByLex` 명령어를 활용하여, **주식 종목명/코드 검색 및 자동완성 기능**을 구현했습니다.
단순 텍스트 매칭이 아닌 **한글 자소 분리(Jaso) 및 초성 검색** 로직을 적용하여, 사용자가 '삼성전자'를 검색할 때 'ㅅㅅㅈㅈ' 또는 분리된 자소 입력으로도 검색이 가능하도록 사용자 편의성을 높였습니다.

Redis를 이용한 주식 종목(Ticker) 자동완성 데이터 적재 및 검색 기능을 구현했습니다.
`JwtAuthenticationFilter` 및 `Infrastructure`계층에서 Redis 연결 실패 시 발생하는 예외 처리를 세분화했습니다.
보안 필터에서 발생하는 에러 응답 포맷을 기존 `BaseResponse`에서 `ErrorResponse`로 통일했습니다.

---

## 작업 내용

- **TickerController**
  - 주식 종목 데이터 적재 API (`/add`) 구현 (`/search`) 조회를 위한 테스트용
  - 검색어 기반 종목 조회 API (`/search`) 구현
- **TickerService**
  - 한글 자소 분리(Jaso) 및 초성 추출 유틸리티 적용
  - 검색어 입력 시 자소 단위로 변환하여 검색 로직 수행
- **TickerRedisRepository**
  - `StringRedisTemplate`을 사용하여 Redis ZSet에 데이터 저장
  - `rangeByLex`를 활용한 접두사(Prefix) 기반 범위 검색 구현 (Score를 0으로 고정하여 사전순 정렬 활용)
- 보안 필터 예외 처리 강화 `JwtAuthenticationFilter`
  - JWT 블랙리스트 확인 시 Redis 연결이 실패할 경우, 보안을 위해 로그인을 차단(Fail Closed)하고 예외를 발생시키도록 수정
---

## 관련 이슈

- #13 