### PR TITLE
Hotfix/kakao login

### DIFF
--- a/src/main/java/com/joojoo/api/user/application/auth/AuthSocialService.java
+++ b/src/main/java/com/joojoo/api/user/application/auth/AuthSocialService.java
@@ -5,9 +5,8 @@ import com.joojoo.api.user.presentation.dto.response.LoginResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface AuthSocialService {
-    LoginResponse kakaoSocialLogin(String code);
+    LoginResponse kakaoWebSocialLogin(String code);
+    LoginResponse kakaoAppSocialLogin(AuthTokenDto authTokenDto);
     LoginResponse appleSocialLogin(String code);
     void withdraw(Long userId, HttpServletRequest request);
-
-    LoginResponse kakaoAppSocialLogin(AuthTokenDto authTokenDto);
 }

--- a/src/main/java/com/joojoo/api/user/application/auth/AuthSocialService.java
+++ b/src/main/java/com/joojoo/api/user/application/auth/AuthSocialService.java
@@ -1,5 +1,6 @@
 package com.joojoo.api.user.application.auth;
 
+import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
 import com.joojoo.api.user.presentation.dto.response.LoginResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -7,4 +8,6 @@ public interface AuthSocialService {
     LoginResponse kakaoSocialLogin(String code);
     LoginResponse appleSocialLogin(String code);
     void withdraw(Long userId, HttpServletRequest request);
+
+    LoginResponse kakaoAppSocialLogin(AuthTokenDto authTokenDto);
 }

--- a/src/main/java/com/joojoo/api/user/application/auth/AuthSocialServiceImpl.java
+++ b/src/main/java/com/joojoo/api/user/application/auth/AuthSocialServiceImpl.java
@@ -12,7 +12,6 @@ import com.joojoo.api.user.presentation.dto.request.apple.AppleUserInfo;
 import com.joojoo.api.user.presentation.dto.request.kakao.AccessTokenDto;
 import com.joojoo.api.user.presentation.dto.request.kakao.KakaoUserDto;
 import com.joojoo.api.user.presentation.dto.response.LoginResponse;
-import com.joojoo.global.exception.handleException.auth.InvalidAuthorizationException;
 import com.joojoo.global.exception.handleException.users.UserNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -35,15 +34,12 @@ public class AuthSocialServiceImpl implements AuthSocialService {
 
     @Override
     @Transactional
-    public LoginResponse kakaoSocialLogin(String code) {
+    public LoginResponse kakaoWebSocialLogin(String code) {
         AccessTokenDto kakaoAccessToken = kakaoClientSecret.getKakaoAccessToken(code);
         KakaoUserDto userInfo = kakaoClientSecret.getUserInfoFromKakao(kakaoAccessToken.getAccessToken());
 
         User user = registerOrLogin(userInfo, kakaoAccessToken.getRefreshToken());
-        String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user);
-        String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName());
-
-        return LoginResponse.of(user, accessToken, refreshToken);
+        return generateLoginResponse(user);
     }
 
     @Override
@@ -51,10 +47,7 @@ public class AuthSocialServiceImpl implements AuthSocialService {
         KakaoUserDto userInfo = kakaoClientSecret.getUserInfoFromKakao(authTokenDto.getAccessToken());
 
         User user = registerOrLogin(userInfo, authTokenDto.getRefreshToken());
-        String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user);
-        String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName());
-
-        return LoginResponse.of(user, accessToken, refreshToken);
+        return generateLoginResponse(user);
     }
 
     @Override
@@ -62,17 +55,10 @@ public class AuthSocialServiceImpl implements AuthSocialService {
     public LoginResponse appleSocialLogin(String code) {
         String clientSecret = appleClientSecret.createClientSecret();
         AppleTokenResponse appleTokenResponse = appleClientSecret.requestAppleToken(code, clientSecret);
-        log.info("Apple Token Response: {}", appleTokenResponse);
-
         AppleUserInfo appleUser = getAppleUserInfo(appleTokenResponse.getIdToken());
-        log.info("Apple User ID: {}", appleUser.getProviderId());
-        log.info("Apple User Email: {}", appleUser.getEmail());
 
-        User user = registerOrLogin(appleUser.getProviderId(), appleTokenResponse, appleUser.getEmail());
-        String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user);
-        String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName());
-
-        return LoginResponse.of(user, accessToken, refreshToken);
+        User user = registerOrLogin(appleUser.getProviderId(), appleTokenResponse.getRefreshToken(), appleUser.getEmail());
+        return generateLoginResponse(user);
     }
 
     @Override
@@ -95,6 +81,12 @@ public class AuthSocialServiceImpl implements AuthSocialService {
         }
     }
 
+    private LoginResponse generateLoginResponse(User user){
+        String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user);
+        String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName());
+        return LoginResponse.of(user, accessToken, refreshToken);
+    }
+
     private User registerOrLogin(KakaoUserDto kakaoUser, String socialRefreshToken) {
         return userRepository.findByEmail(kakaoUser.getEmail())
             .map(user -> {
@@ -113,16 +105,16 @@ public class AuthSocialServiceImpl implements AuthSocialService {
         return AppleUserInfo.from(claims);
     }
 
-    private User registerOrLogin(String providerId, AppleTokenResponse appleTokenResponse, String email) {
+    private User registerOrLogin(String providerId, String appleRefreshToken, String email) {
         return userRepository.findByProviderId(providerId)
                 .map(user -> {
-                    if (appleTokenResponse.getRefreshToken() != null) {
-                        user.updateSocialRefreshToken(appleTokenResponse.getRefreshToken());
+                    if (appleRefreshToken != null) {
+                        user.updateSocialRefreshToken(appleRefreshToken);
                     }
                     return user;
                 })
                 .orElseGet(() -> {
-                    User newUser = User.createAppleUserBuilder(providerId, email, appleTokenResponse.getRefreshToken());
+                    User newUser = User.createAppleUserBuilder(providerId, email, appleRefreshToken);
                     return userRepository.save(newUser);
                 });
     }

--- a/src/main/java/com/joojoo/api/user/application/auth/AuthSocialServiceImpl.java
+++ b/src/main/java/com/joojoo/api/user/application/auth/AuthSocialServiceImpl.java
@@ -6,6 +6,7 @@ import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
 import com.joojoo.api.user.domain.service.auth.AppleClientSecret;
 import com.joojoo.api.user.domain.service.auth.KakaoClientSecret;
+import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
 import com.joojoo.api.user.presentation.dto.request.apple.AppleTokenResponse;
 import com.joojoo.api.user.presentation.dto.request.apple.AppleUserInfo;
 import com.joojoo.api.user.presentation.dto.request.kakao.AccessTokenDto;
@@ -39,6 +40,17 @@ public class AuthSocialServiceImpl implements AuthSocialService {
         KakaoUserDto userInfo = kakaoClientSecret.getUserInfoFromKakao(kakaoAccessToken.getAccessToken());
 
         User user = registerOrLogin(userInfo, kakaoAccessToken.getRefreshToken());
+        String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user);
+        String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName());
+
+        return LoginResponse.of(user, accessToken, refreshToken);
+    }
+
+    @Override
+    public LoginResponse kakaoAppSocialLogin(AuthTokenDto authTokenDto) {
+        KakaoUserDto userInfo = kakaoClientSecret.getUserInfoFromKakao(authTokenDto.getAccessToken());
+
+        User user = registerOrLogin(userInfo, authTokenDto.getRefreshToken());
         String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user);
         String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName());
 

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -3,6 +3,7 @@ package com.joojoo.api.user.presentation.controller;
 import com.joojoo.api.user.application.UserService;
 import com.joojoo.api.user.application.auth.AuthSocialService;
 import com.joojoo.api.user.presentation.dto.request.AuthCodeDto;
+import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
 import com.joojoo.api.user.presentation.dto.response.LoginResponse;
 import com.joojoo.global.common.request.auth.CustomUserDetails;
 import com.joojoo.global.common.response.BaseResponse;
@@ -30,23 +31,28 @@ public class UserController {
     private final AuthSocialService authSocialService;
     private final UserService userService;
 
-    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 전달받아 소셜 로그인을 진행합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드",
-                    content = @Content(
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(responseCode = "502", description = "카카오 서버 통신 오류",
-                    content = @Content(
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            )
-    })
+//    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 전달받아 소셜 로그인을 진행합니다.")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+//            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드",
+//                    content = @Content(
+//                            schema = @Schema(implementation = ErrorResponse.class)
+//                    )
+//            ),
+//            @ApiResponse(responseCode = "502", description = "카카오 서버 통신 오류",
+//                    content = @Content(
+//                            schema = @Schema(implementation = ErrorResponse.class)
+//                    )
+//            )
+//    })
+//    @PostMapping("/kakao/login")
+//    public BaseResponse<LoginResponse> kakaoLogin(@RequestBody AuthCodeDto payload) {
+//        return BaseResponse.ok(authSocialService.kakaoSocialLogin(payload.getCode()));
+//    }
+
     @PostMapping("/kakao/login")
-    public BaseResponse<LoginResponse> kakaoLogin(@RequestBody AuthCodeDto payload) {
-        return BaseResponse.ok(authSocialService.kakaoSocialLogin(payload.getCode()));
+    public BaseResponse<LoginResponse> kakaoAppLogin(@RequestBody AuthTokenDto authTokenDto) {
+        return BaseResponse.ok(authSocialService.kakaoAppSocialLogin(authTokenDto));
     }
 
     @Operation(summary = "애플 로그인", description = "애플 인가 코드를 전달받아 소셜 로그인을 진행합니다.")

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -31,25 +31,20 @@ public class UserController {
     private final AuthSocialService authSocialService;
     private final UserService userService;
 
-//    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 전달받아 소셜 로그인을 진행합니다.")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "로그인 성공"),
-//            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드",
-//                    content = @Content(
-//                            schema = @Schema(implementation = ErrorResponse.class)
-//                    )
-//            ),
-//            @ApiResponse(responseCode = "502", description = "카카오 서버 통신 오류",
-//                    content = @Content(
-//                            schema = @Schema(implementation = ErrorResponse.class)
-//                    )
-//            )
-//    })
-//    @PostMapping("/kakao/login")
-//    public BaseResponse<LoginResponse> kakaoLogin(@RequestBody AuthCodeDto payload) {
-//        return BaseResponse.ok(authSocialService.kakaoSocialLogin(payload.getCode()));
-//    }
-
+    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 전달받아 소셜 로그인을 진행합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "502", description = "카카오 서버 통신 오류",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
     @PostMapping("/kakao/login")
     public BaseResponse<LoginResponse> kakaoAppLogin(@RequestBody AuthTokenDto authTokenDto) {
         return BaseResponse.ok(authSocialService.kakaoAppSocialLogin(authTokenDto));

--- a/src/main/java/com/joojoo/api/user/presentation/dto/request/AuthTokenDto.java
+++ b/src/main/java/com/joojoo/api/user/presentation/dto/request/AuthTokenDto.java
@@ -1,0 +1,11 @@
+package com.joojoo.api.user.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthTokenDto {
+    private String accessToken;
+    private String refreshToken;
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Refactor] 카카오 앱 로그인 지원 및 토큰 생성 로직 리팩토링

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

기존 웹(Web) 방식의 카카오 로그인 로직을 앱(App) 환경에서도 지원하도록 수정하고, 중복되는 인증 토큰 발급 및 응답 생성 로직을 별도 메서드로 분리하여 리팩토링했습니다.

---

## 작업 내용

- **카카오 앱(App) 로그인 지원**
  - 기존 인가 코드(Authorization Code) 방식 외에, 앱에서 전달받은 `AccessToken`을 통해 카카오 유저 정보를 조회하고 로그인 처리하는 `kakaoAppSocialLogin` 로직 구현
- **로그인 응답 생성 로직 리팩토링**
  - 로그인 성공 후 `AccessToken` 및 `RefreshToken`을 발급하고 `LoginResponse` 객체를 생성하는 로직이 중복되어 `generateLoginResponse` 메서드로 분리
  - 코드 중복 제거 및 비즈니스 로직 가독성 향상

---

## 관련 이슈

