### PR TITLE
feat: Access Token 재발급 기능 구현 및 성능 최적화

### DIFF
--- a/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCase.java
+++ b/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCase.java
@@ -1,5 +1,6 @@
 package com.joojoo.api.jwt.application;
 
+import com.joojoo.api.jwt.presentation.dto.response.ReissueTokenResponse;
 import com.joojoo.api.user.domain.model.entity.User;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -12,4 +13,7 @@ public interface JwtTokenUseCase {
 
     // 로그아웃시 토큰 블랙리스트 삽입 및 DB제거
     void clearUserTokens(Long userId, HttpServletRequest request);
+
+    // Refresh 토큰으로 AccessToken을 재 발급
+    ReissueTokenResponse reissueAccessToken(String refreshToken);
 }

--- a/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCaseImpl.java
+++ b/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCaseImpl.java
@@ -1,14 +1,21 @@
 package com.joojoo.api.jwt.application;
 
 import com.joojoo.api.jwt.domain.model.entity.Token;
+import com.joojoo.api.jwt.domain.repository.TokenBlacklistRepository;
 import com.joojoo.api.jwt.domain.repository.TokenRepository;
 import com.joojoo.api.jwt.domain.service.JwtProvider;
-import com.joojoo.api.jwt.domain.repository.TokenBlacklistRepository;
+import com.joojoo.api.jwt.presentation.dto.response.ReissueTokenResponse;
 import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.global.common.request.auth.CustomUserDetails;
 import com.joojoo.global.common.util.TokenExpirationUtil;
+import com.joojoo.global.exception.handleException.jwt.RefreshTokenExpiredException;
+import com.joojoo.global.exception.handleException.jwt.TokenVerificationException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +63,29 @@ public class JwtTokenUseCaseImpl implements JwtTokenUseCase {
 
         tokenBlacklistRepository.add(accessToken, expiration); // AccessToken 블랙리스트에 저장
         tokenRepository.delete(userId); // DB에서 RefreshToken 삭제
+    }
+
+    @Override
+    public ReissueTokenResponse reissueAccessToken(String refreshToken) {
+        validateToken(refreshToken);
+        Authentication authentication = jwtProvider.getAuthentication(refreshToken);
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        Token storedToken = tokenRepository.findByUserId(userDetails.getUserId())
+                .orElseThrow(RefreshTokenExpiredException::new);
+
+        storedToken.validateSameToken(refreshToken);
+        return new ReissueTokenResponse(jwtProvider.createAccessToken(userDetails.getUserId(), userDetails.getUsername()));
+    }
+
+    private void validateToken(String refreshToken) {
+        try {
+            jwtProvider.validateToken(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new RefreshTokenExpiredException();
+        } catch (JwtException e) {
+            throw new TokenVerificationException();
+        }
     }
 
 }

--- a/src/main/java/com/joojoo/api/jwt/domain/model/entity/Token.java
+++ b/src/main/java/com/joojoo/api/jwt/domain/model/entity/Token.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.jwt.domain.model.entity;
 
 import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.global.exception.handleException.jwt.TokenVerificationException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +20,7 @@ public class Token {
     @Column(name = "token_id")
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -47,5 +48,11 @@ public class Token {
     public void updateRefreshToken(String refreshToken, LocalDateTime expiresAt) {
         this.refreshToken = refreshToken;
         this.expiresAt = expiresAt;
+    }
+
+    public void validateSameToken(String refreshToken) {
+        if (!this.refreshToken.equals(refreshToken)) {
+            throw new TokenVerificationException();
+        }
     }
 }

--- a/src/main/java/com/joojoo/api/jwt/infrastructure/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/joojoo/api/jwt/infrastructure/jwt/JwtProviderImpl.java
@@ -2,7 +2,11 @@ package com.joojoo.api.jwt.infrastructure.jwt;
 
 import com.joojoo.api.jwt.domain.service.JwtProvider;
 import com.joojoo.global.common.request.auth.CustomUserDetails;
-import io.jsonwebtoken.*;
+import com.joojoo.global.exception.handleException.jwt.TokenVerificationException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -93,6 +97,11 @@ public class JwtProviderImpl implements JwtProvider {
             .getPayload();
 
         String username = claims.getSubject();
+        Object userIdObj = claims.get("userId");
+
+        if (userIdObj == null) { // userId NPE 방지
+            throw new TokenVerificationException();
+        }
         Long userId = Long.valueOf(claims.get("userId").toString());
 
         CustomUserDetails user = new CustomUserDetails(userId, username);

--- a/src/main/java/com/joojoo/api/jwt/presentation/controller/JwtController.java
+++ b/src/main/java/com/joojoo/api/jwt/presentation/controller/JwtController.java
@@ -1,0 +1,46 @@
+package com.joojoo.api.jwt.presentation.controller;
+
+import com.joojoo.api.jwt.application.JwtTokenUseCase;
+import com.joojoo.api.jwt.presentation.dto.request.TokenReissueDto;
+import com.joojoo.api.jwt.presentation.dto.response.ReissueTokenResponse;
+import com.joojoo.global.common.response.BaseResponse;
+import com.joojoo.global.common.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "JWT API", description = "JWT 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/token")
+public class JwtController {
+
+    private final JwtTokenUseCase jwtTokenUseCase;
+
+    @Operation(summary = "AccessToken 재발급", description = "RefreshToken을 이용해 새로운 AccessToken을 받는다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @ApiResponse(responseCode = "401", description = "Refresh 토큰이 만료 되었습니다.",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "422", description = "유효하지 않은 토큰입니다.",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    @PostMapping("/reissue")
+    public BaseResponse<ReissueTokenResponse> refresh(@RequestBody TokenReissueDto tokenReissueDto) {
+        return BaseResponse.ok(jwtTokenUseCase.reissueAccessToken(tokenReissueDto.getRefreshToken()));
+    }
+}

--- a/src/main/java/com/joojoo/api/jwt/presentation/dto/request/TokenReissueDto.java
+++ b/src/main/java/com/joojoo/api/jwt/presentation/dto/request/TokenReissueDto.java
@@ -1,0 +1,10 @@
+package com.joojoo.api.jwt.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenReissueDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/joojoo/api/jwt/presentation/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/com/joojoo/api/jwt/presentation/dto/response/ReissueTokenResponse.java
@@ -1,0 +1,10 @@
+package com.joojoo.api.jwt.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReissueTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/joojoo/api/ticker/presentation/controller/TickerController.java
+++ b/src/main/java/com/joojoo/api/ticker/presentation/controller/TickerController.java
@@ -1,4 +1,4 @@
-package com.joojoo.api.ticker.presentation;
+package com.joojoo.api.ticker.presentation.controller;
 
 import com.joojoo.api.ticker.application.TickerService;
 import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;

--- a/src/main/java/com/joojoo/global/config/SecurityConfig.java
+++ b/src/main/java/com/joojoo/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource))
 
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/user/kakao/login", "/user/apple/login", "/ticker/add").permitAll()
+                .requestMatchers("/user/kakao/login", "/user/apple/login", "/token/reissue").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                 .requestMatchers("/health/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/joojoo/global/exception/handleException/jwt/RefreshTokenExpiredException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/jwt/RefreshTokenExpiredException.java
@@ -1,0 +1,17 @@
+package com.joojoo.global.exception.handleException.jwt;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class RefreshTokenExpiredException extends ServiceException {
+
+    private static final ErrorCode errorCode = ErrorCode.EXPIRED_REFRESH_TOKEN;
+
+    public RefreshTokenExpiredException() {
+        super(errorCode);
+    }
+
+    public RefreshTokenExpiredException(Exception exception) {
+        super(errorCode, exception);
+    }
+}

--- a/src/main/java/com/joojoo/global/exception/handleException/jwt/TokenVerificationException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/jwt/TokenVerificationException.java
@@ -1,0 +1,17 @@
+package com.joojoo.global.exception.handleException.jwt;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class TokenVerificationException extends ServiceException {
+
+    private static final ErrorCode errorCode = ErrorCode.INVALID_TOKEN;
+
+    public TokenVerificationException() {
+        super(errorCode);
+    }
+
+    public TokenVerificationException(Exception exception) {
+        super(errorCode, exception);
+    }
+}

--- a/src/main/java/com/joojoo/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/joojoo/global/jwt/filter/JwtAuthenticationFilter.java
@@ -3,7 +3,6 @@ package com.joojoo.global.jwt.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.joojoo.api.jwt.domain.repository.TokenBlacklistRepository;
 import com.joojoo.api.jwt.domain.service.JwtProvider;
-import com.joojoo.global.common.response.BaseResponse;
 import com.joojoo.global.common.response.ErrorResponse;
 import com.joojoo.global.exception.handleException.redis.RedisConnectionFailException;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -16,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -26,14 +26,29 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final TokenBlacklistRepository tokenBlacklistRepository;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
-    private final List<String> excludedUrls = List.of( // 인증 제외 URL
-        "/user/kakao/login", "/user/apple/login", "/ticker/add"
+    private final List<String> excludedUrls = List.of(
+            "/user/kakao/login",
+            "/user/apple/login",
+            "/token/reissue",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/health/**"
     );
 
     public JwtAuthenticationFilter(JwtProvider jwtProvider, TokenBlacklistRepository tokenBlacklistRepository) {
         this.jwtProvider = jwtProvider;
         this.tokenBlacklistRepository = tokenBlacklistRepository;
+    }
+
+    // shouldNotFilter 메서드가 true를 반환하면 doFilterInternal메서드는 실행되지 않음
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        return excludedUrls.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
     }
 
     @Override
@@ -42,10 +57,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         log.info("request.getRequestURI() = {}", request.getRequestURI());
 
         try {
-            if (isExcludedUrl(request)) { // 필터 제외 URL이면 바로 다음 필터로 진행
-                filterChain.doFilter(request, response);
-                return;
-            }
             authenticateIfTokenExists(request); // JWT 인증 처리 후 SecurityContext에 User정보 저장
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
@@ -73,12 +84,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         jwtProvider.validateToken(token);
         Authentication auth = jwtProvider.getAuthentication(token);
         SecurityContextHolder.getContext().setAuthentication(auth);
-    }
-
-    // 인증 제외 URL인지 검증
-    private boolean isExcludedUrl(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return excludedUrls.contains(path);
     }
 
     private void setErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] Access Token 재발급 기능 구현 및 JWT 필터 최적화

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

만료된 Access Token을 Refresh Token을 검증하여 재발급하는 기능을 구현하고, JWT 필터 제외 처리 최적화 및 DB 조회 성능 개선(N+1 문제 해결)을 수행했습니다.

---

## 작업 내용

- **Access Token 재발급 로직 구현**
  - `/token/reissue` API 추가
  - Refresh Token 유효성 검증 및 만료 여부 확인 로직 작성 (`reissueAccessToken`)
  - `RefreshTokenExpiredException`, `TokenVerificationException` 등 예외 처리 클래스 추가
- **Token 엔티티 리팩토링 및 성능 개선**
  - `User` 연관관계 `FetchType.LAZY` 적용으로 불필요한 조인 쿼리(N+1) 제거
  - 토큰 일치 여부 검증 로직을 서비스에서 엔티티(`validateSameToken`)로 이동하여 캡슐화 강화
- **Security Filter 최적화**
  - `JwtAuthenticationFilter`에 `shouldNotFilter` 메서드 오버라이드 적용
  - `AntPathMatcher`를 도입하여 재발급 API, Swagger, Health Check 등 특정 경로에 대한 필터링 제외 처리 (불필요한 로직 수행 방지)
 
---

## 관련 이슈

