### PR TITLE
feat: 주식 데이터 CSV파일 DB 대량 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // OpenCSV
+    implementation 'com.opencsv:opencsv:5.8'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/joojoo/api/ticker/application/TickerService.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerService.java
@@ -6,4 +6,7 @@ public interface TickerService {
     void addStockToRedis(String name, String ticker);
 
     TickerSearchResponse search(String query);
+
+    // 배포하지는 않고 로컬에서 csv 파일 실행 해 운영 DB에 데이터 넣기
+    void initTickerData();
 }

--- a/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
@@ -1,24 +1,32 @@
 package com.joojoo.api.ticker.application;
 
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.ticker.domain.repository.TickerRedisRepository;
+import com.joojoo.api.ticker.domain.repository.TickerRepository;
+import com.joojoo.api.ticker.domain.provider.TickerDataProvider;
+import com.joojoo.api.ticker.presentation.dto.request.TickerDataDto;
 import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;
 import com.joojoo.global.exception.handleException.tickers.InvalidTickerOrNameException;
 import com.joojoo.global.util.HangulUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TickerServiceImpl implements TickerService {
 
     private final TickerRedisRepository tickerRedisRepository;
+    private final TickerRepository tickerRepository;
+    private final TickerDataProvider tickerDataProvider;
 
     @Override
     public void addStockToRedis(String name, String ticker) {
@@ -41,4 +49,30 @@ public class TickerServiceImpl implements TickerService {
         Range<String> range = Range.rightOpen(convertedQuery, convertedQuery + "\uffff");
         return TickerSearchResponse.of(tickerRedisRepository.searchTickerQuery(range, Limit.limit().count(10)));
     }
+
+    @Transactional
+    public void initTickerData() {
+        List<TickerDataDto> externalStocks = tickerDataProvider.getTickerCsvData();
+
+        // 과연 전체 주식을 다 가져오는게 효율적일 까??
+        Map<String, Ticker> existingTickerMap = tickerRepository.findAll().stream()
+                .collect(Collectors.toMap(Ticker::getSymbol, ticker -> ticker));
+
+        List<Ticker> saveList = new ArrayList<>();
+
+        for (TickerDataDto data : externalStocks) {
+            Ticker ticker = existingTickerMap.get(data.getSymbol());
+
+            if (ticker != null) {
+                ticker.updateInfo(data.getName(), data.getMarket(), data.getListingDate());
+                saveList.add(ticker);
+            } else {
+                saveList.add(new Ticker(data.getSymbol(), data.getName(), data.getMarket(), data.getListingDate()));
+            }
+        }
+
+        tickerRepository.saveAll(saveList);
+        log.info("티커 데이터 업데이트 완료: {}건 처리됨", saveList.size());
+    }
+
 }

--- a/src/main/java/com/joojoo/api/ticker/domain/model/entity/Ticker.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/model/entity/Ticker.java
@@ -1,0 +1,54 @@
+package com.joojoo.api.ticker.domain.model.entity;
+
+import com.joojoo.api.ticker.domain.model.enums.MarketType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tickers")
+public class Ticker {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "symbol", nullable = false, unique = true)
+    private String symbol;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private MarketType market;
+
+    @Column(name = "listing_date")
+    private LocalDate listingDate; // 상장 일
+
+    @Column(name = "delisting_date")
+    private LocalDate delistingDate; // 폐지 일
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
+
+    @Builder
+    public Ticker(String symbol, String name, MarketType market, LocalDate listingDate) {
+        this.symbol = symbol;
+        this.name = name;
+        this.market = market;
+        this.listingDate = listingDate;
+    }
+
+    public void updateInfo(String name, MarketType market, LocalDate listingDate) {
+        this.name = name;
+        this.market = market;
+        this.listingDate = listingDate;
+    }
+
+}

--- a/src/main/java/com/joojoo/api/ticker/domain/model/enums/MarketType.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/model/enums/MarketType.java
@@ -1,0 +1,31 @@
+package com.joojoo.api.ticker.domain.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MarketType {
+
+    KOSPI("코스피"),
+    KOSDAQ("코스닥"),
+    KOSDAQ_GLOBAL("코스닥 글로벌"),
+    KONEX("코넥스"),
+    ETC("기타"),
+    ;
+
+    private final String text;
+
+    public static MarketType fromString(String market) {
+        if (market == null || market.isBlank()) {
+            return ETC;
+        }
+
+        String normalizedMarket = market.toUpperCase().replace(" ", "_");
+        try {
+            return MarketType.valueOf(normalizedMarket);
+        } catch (IllegalArgumentException e) {
+            return ETC;
+        }
+    }
+}

--- a/src/main/java/com/joojoo/api/ticker/domain/provider/TickerDataProvider.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/provider/TickerDataProvider.java
@@ -1,0 +1,9 @@
+package com.joojoo.api.ticker.domain.provider;
+
+import com.joojoo.api.ticker.presentation.dto.request.TickerDataDto;
+
+import java.util.List;
+
+public interface TickerDataProvider {
+    List<TickerDataDto> getTickerCsvData();
+}

--- a/src/main/java/com/joojoo/api/ticker/domain/repository/TickerRepository.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/repository/TickerRepository.java
@@ -1,0 +1,11 @@
+package com.joojoo.api.ticker.domain.repository;
+
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+
+import java.util.List;
+
+public interface TickerRepository {
+    void saveAll(List<Ticker> tickerList);
+
+    List<Ticker> findAll();
+}

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/csv/TickerDataProviderImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/csv/TickerDataProviderImpl.java
@@ -1,0 +1,57 @@
+package com.joojoo.api.ticker.infrastructure.csv;
+
+import com.joojoo.api.ticker.domain.model.enums.MarketType;
+import com.joojoo.api.ticker.domain.provider.TickerDataProvider;
+import com.joojoo.api.ticker.presentation.dto.request.TickerDataDto;
+import com.opencsv.CSVReader;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Repository;
+
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Repository
+public class TickerDataProviderImpl implements TickerDataProvider {
+
+    private static final String FILE_PATH = "data/stocks.csv";
+
+    @Override
+    public List<TickerDataDto> getTickerCsvData() {
+        List<TickerDataDto> result = new ArrayList<>();
+        ClassPathResource resource = new ClassPathResource(FILE_PATH);
+
+        try (CSVReader csvReader = new CSVReader(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8))) {
+            List<String[]> rows = csvReader.readAll();
+
+            for (int i = 1; i < rows.size(); i++) {
+                String[] row = rows.get(i);
+                if (isValidRow(row)) {
+                    result.add(mapToDto(row));
+                }
+            }
+        } catch (Exception e) {
+            log.error("CSV 파싱 실패", e);
+            throw new RuntimeException("주식 데이터 로드 실패", e);
+        }
+        return result;
+    }
+
+    private boolean isValidRow(String[] row) {
+        return row.length >= 7 && row[1] != null && !row[1].isBlank();
+    }
+
+    private TickerDataDto mapToDto(String[] row) {
+        return new TickerDataDto(
+                row[1], // symbol
+                row[2], // name
+                MarketType.fromString(row[6]),
+                LocalDate.parse(row[5], DateTimeFormatter.ISO_DATE)
+        );
+    }
+}

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/rdbms/TickerJpaRepository.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/rdbms/TickerJpaRepository.java
@@ -1,0 +1,9 @@
+package com.joojoo.api.ticker.infrastructure.rdbms;
+
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TickerJpaRepository extends JpaRepository<Ticker, Long> {
+}

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/rdbms/TickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/rdbms/TickerRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.joojoo.api.ticker.infrastructure.rdbms;
+
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import com.joojoo.api.ticker.domain.repository.TickerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TickerRepositoryImpl implements TickerRepository {
+
+    private final TickerJpaRepository tickerJpaRepository;
+
+
+    @Override
+    public void saveAll(List<Ticker> tickerList) {
+        tickerJpaRepository.saveAll(tickerList);
+    }
+
+    @Override
+    public List<Ticker> findAll() {
+        return tickerJpaRepository.findAll();
+    }
+}

--- a/src/main/java/com/joojoo/api/ticker/presentation/dto/request/TickerDataDto.java
+++ b/src/main/java/com/joojoo/api/ticker/presentation/dto/request/TickerDataDto.java
@@ -1,0 +1,16 @@
+package com.joojoo.api.ticker.presentation.dto.request;
+
+import com.joojoo.api.ticker.domain.model.enums.MarketType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class TickerDataDto {
+    private String symbol;
+    private String name;
+    private MarketType market;
+    private LocalDate listingDate;
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 주식 데이터 CSV파일 DB 대량 저장

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [ ] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [ ] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

로컬에서 CSV 파일을 실행시켜 운영 DB에 주식 데이터 저장 구현

---

## 작업 내용

- 주식 초기 데이터 적재 기능 구현
  - CSV 파일을 파싱하여 시스템에 필요한 포맷(`TickerDataDto`)으로 변환하는 로직 구현
- 데이터 동기화 로직 (Upsert) 구현
  - 기존 DB 데이터와 파일 데이터를 비교하여 신규 종목은 INSERT, 기존 종목은 UPDATE 처리
- MarketType Enum 변환 로직 구현
  - `KOSDAQ GLOBAL` 띄어쓰기를 `replace` 함수를 사용해 `KOSDAQ_GLOBAL`로 변환
---

## 관련 이슈

