### PR TITLE
feat: 기본 프로필 이미지 조회 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/user/application/UserService.java
+++ b/src/main/java/com/joojoo/api/user/application/UserService.java
@@ -1,7 +1,10 @@
 package com.joojoo.api.user.application;
 
+import com.joojoo.api.user.presentation.dto.response.DefaultProfileImageResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserService {
     void logout(Long userId, HttpServletRequest request);
+
+    DefaultProfileImageResponse getDefaultProfileImages();
 }

--- a/src/main/java/com/joojoo/api/user/application/UserServiceImpl.java
+++ b/src/main/java/com/joojoo/api/user/application/UserServiceImpl.java
@@ -2,11 +2,17 @@ package com.joojoo.api.user.application;
 
 import com.joojoo.api.jwt.application.JwtTokenUseCase;
 import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.api.user.domain.model.enums.DefaultProfileImage;
+import com.joojoo.api.user.domain.provider.fileService;
 import com.joojoo.api.user.domain.repository.UserRepository;
+import com.joojoo.api.user.presentation.dto.response.DefaultProfileImageResponse;
 import com.joojoo.global.exception.handleException.users.UserNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +20,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final JwtTokenUseCase jwtTokenUseCase;
+    private final fileService fileService;
 
     @Override
     public void logout(Long userId, HttpServletRequest request) {
@@ -24,6 +31,16 @@ public class UserServiceImpl implements UserService {
         jwtTokenUseCase.clearUserTokens(userId, request);
     }
 
-
+    @Override
+    public DefaultProfileImageResponse getDefaultProfileImages() {
+        return DefaultProfileImageResponse.of(Arrays.stream(DefaultProfileImage.values())
+                .map(img -> new DefaultProfileImageResponse.ProfileImage(
+                        img.name(),
+                        fileService.getFullUrl(img.getFileName()),
+                        img.getDescription()
+                ))
+                .collect(Collectors.toList())
+        );
+    }
 
 }

--- a/src/main/java/com/joojoo/api/user/domain/model/enums/DefaultProfileImage.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/enums/DefaultProfileImage.java
@@ -1,0 +1,15 @@
+package com.joojoo.api.user.domain.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DefaultProfileImage {
+    PROFILE_1("profile1", "기본 프로필1"),
+    PROFILE_2("profile2", "기본 프로필2"),
+    ;
+
+    private final String fileName;
+    private final String description;
+}

--- a/src/main/java/com/joojoo/api/user/domain/provider/fileService.java
+++ b/src/main/java/com/joojoo/api/user/domain/provider/fileService.java
@@ -1,0 +1,5 @@
+package com.joojoo.api.user.domain.provider;
+
+public interface fileService {
+    String getFullUrl(String fileName);
+}

--- a/src/main/java/com/joojoo/api/user/infrastructure/image/fileServiceImpl.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/image/fileServiceImpl.java
@@ -1,0 +1,20 @@
+package com.joojoo.api.user.infrastructure.image;
+
+import com.joojoo.api.user.domain.provider.fileService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class fileServiceImpl implements fileService {
+
+    @Value("${STORAGE_ENDPOINT}")
+    private String endPoint;
+
+    @Value("${BUCKET_NAME}")
+    private String bucket;
+
+    @Override
+    public String getFullUrl(String fileName) {
+        return endPoint + bucket + fileName;
+    }
+}

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -4,6 +4,7 @@ import com.joojoo.api.user.application.UserService;
 import com.joojoo.api.user.application.auth.AuthSocialService;
 import com.joojoo.api.user.presentation.dto.request.AuthCodeDto;
 import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
+import com.joojoo.api.user.presentation.dto.response.DefaultProfileImageResponse;
 import com.joojoo.api.user.presentation.dto.response.LoginResponse;
 import com.joojoo.global.common.request.auth.CustomUserDetails;
 import com.joojoo.global.common.response.BaseResponse;
@@ -17,10 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User API", description = "유저 관련 API")
 @RestController
@@ -98,4 +96,14 @@ public class UserController {
         userService.logout(user.getUserId(), request);
         return BaseResponse.ok("로그아웃이 완료되었습니다.");
     }
+
+    @Operation(summary = "기본 프로필 API", description = "기본 프로필 이미지 리스트를 반홥합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 조회 성공"),
+    })
+    @GetMapping("/profile-images/default")
+    public BaseResponse<DefaultProfileImageResponse> getDefaultProfileImages(){
+        return BaseResponse.ok(userService.getDefaultProfileImages());
+    }
+
 }

--- a/src/main/java/com/joojoo/api/user/presentation/dto/response/DefaultProfileImageResponse.java
+++ b/src/main/java/com/joojoo/api/user/presentation/dto/response/DefaultProfileImageResponse.java
@@ -1,0 +1,28 @@
+package com.joojoo.api.user.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class DefaultProfileImageResponse {
+    private List<ProfileImage> imageResponse;
+
+    public static DefaultProfileImageResponse of(List<ProfileImage> defaultProfileImages) {
+        return DefaultProfileImageResponse.builder()
+                .imageResponse(defaultProfileImages)
+                .build();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ProfileImage {
+        private String name;
+        private String imageUrl;
+        private String description;
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 기본 프로필 이미지 조회 API 구현 (Enum 기반)

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [ ] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

회원가입 및 프로필 설정 시 사용되는 **기본 프로필 이미지 5종을 DB 테이블 없이 Java Enum으로 관리**하고,  이를 조회할 수 있는 API를 구현하였습니다.  

기본 프로필 이미지는 런타임 중 변경되지 않는 고정 데이터 이므로, DB로 관리할 경우 조회를 위한 불필요한 I/O 비용과 관리 포인트가 추가된다고 판단했습니다.
Enum을 사용함으로써 이미지 ID, 파일명, 설명 등의 메타데이터를 하나의 타입으로 안전하게 관리할 수 있고,
분기문(if, switch) 제거를 통해 확장성과 코드 가독성 또한 개선할 수 있었습니다.

---

## 작업 내용

- `DefaultProfileImage` Enum 클래스 정의
  - 기본 프로필 이미지 2종에 대해 ID, 파일명, 설명 메타데이터 매핑
  - 아직 기본 프로필 이미지를 받지 못해 임시 이미지로 대체
- 기본 프로필 이미지 목록 조회 API 구현
  - `GET /api/profiles/defaults`
  - DB 조회 없이 Enum 데이터를 순회하여 응답 반환
- `FileService`와 연동하여 스토리지 도메인이 포함된 전체 이미지 URL 생성
- 하드코딩된 분기 처리(`if` 문) 제거 후 Enum 기반 구조로 개선

---

## 관련 이슈

- #14 
