### PR TITLE
feat: 프로필, 이름 업데이트 API 구현 및 User - Token 양방향에서 단방향으로 수정

### DIFF
--- a/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCaseImpl.java
+++ b/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCaseImpl.java
@@ -42,12 +42,15 @@ public class JwtTokenUseCaseImpl implements JwtTokenUseCase {
     }
 
     private void registerRefreshToken(User user, String refreshToken, LocalDateTime expiresAt) {
-        Token existingToken = user.getToken();
-        if (existingToken != null) {
-            existingToken.updateRefreshToken(refreshToken, expiresAt);
-        } else {
-            tokenRepository.save(Token.create(user, refreshToken, expiresAt));
-        }
+        tokenRepository.findByUserId(user.getId())
+                .ifPresentOrElse(
+                        existingToken -> {
+                            existingToken.updateRefreshToken(refreshToken, expiresAt);
+                        },
+                        () -> {
+                            tokenRepository.save(Token.create(user, refreshToken, expiresAt));
+                        }
+                );
     }
 
     @Override

--- a/src/main/java/com/joojoo/api/user/application/UserService.java
+++ b/src/main/java/com/joojoo/api/user/application/UserService.java
@@ -1,10 +1,14 @@
 package com.joojoo.api.user.application;
 
+import com.joojoo.api.user.presentation.dto.request.UpdateProfileDto;
 import com.joojoo.api.user.presentation.dto.response.DefaultProfileImageResponse;
+import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserService {
     void logout(Long userId, HttpServletRequest request);
 
     DefaultProfileImageResponse getDefaultProfileImages();
+
+    UserInfoResponse updateProfile(Long userId, UpdateProfileDto updateProfileDto);
 }

--- a/src/main/java/com/joojoo/api/user/application/UserServiceImpl.java
+++ b/src/main/java/com/joojoo/api/user/application/UserServiceImpl.java
@@ -5,11 +5,16 @@ import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.model.enums.DefaultProfileImage;
 import com.joojoo.api.user.domain.provider.fileService;
 import com.joojoo.api.user.domain.repository.UserRepository;
+import com.joojoo.api.user.presentation.dto.request.UpdateProfileDto;
 import com.joojoo.api.user.presentation.dto.response.DefaultProfileImageResponse;
+import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
+import com.joojoo.global.exception.handleException.users.UserNameDuplicatedException;
+import com.joojoo.global.exception.handleException.users.UserNameRequiredException;
 import com.joojoo.global.exception.handleException.users.UserNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -41,6 +46,49 @@ public class UserServiceImpl implements UserService {
                 ))
                 .collect(Collectors.toList())
         );
+    }
+
+    @Override
+    @Transactional
+    public UserInfoResponse updateProfile(Long userId, UpdateProfileDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        validateAndUpdateName(user, dto.getName()); // 이름 검증 및 업데이트
+        updateOrInitProfileImage(user, dto.getProfile()); // 프로필 이미지 업데이트
+
+        return UserInfoResponse.of(user, fileService.getFullUrl(user.getProfileImageUrl()));
+    }
+
+    private void validateAndUpdateName(User user, String newName) {
+        if (newName != null && !newName.isBlank()) {
+            if (!newName.equals(user.getName())) {
+                validateDuplicateNickname(newName);
+            }
+            user.updateName(newName);
+            return;
+        }
+
+        if (user.getName() == null) {
+            throw new UserNameRequiredException();
+        }
+    }
+
+    private void updateOrInitProfileImage(User user, DefaultProfileImage profileImage) {
+        if (profileImage != null) {
+            user.updateProfileImage(profileImage.getFileName());
+            return;
+        }
+
+        if(user.getProfileImageUrl() == null){
+            user.updateProfileImage(DefaultProfileImage.PROFILE_1.getFileName());
+        }
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        if (userRepository.existsByName(nickname)) {
+            throw new UserNameDuplicatedException();
+        }
     }
 
 }

--- a/src/main/java/com/joojoo/api/user/domain/model/entity/User.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/entity/User.java
@@ -1,6 +1,5 @@
 package com.joojoo.api.user.domain.model.entity;
 
-import com.joojoo.api.jwt.domain.model.entity.Token;
 import com.joojoo.api.user.domain.model.enums.Currency;
 import com.joojoo.api.user.domain.model.enums.Provider;
 import com.joojoo.api.user.domain.model.enums.Role;
@@ -50,12 +49,8 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private Role role;
 
-    // 이거 양방향 할 필요가 없는거 같아서 기능 구현후 삭제 할 예정
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
-    private Token token;
-
     @Builder
-    public User(String email, String name, String profileImageUrl, Provider provider, String providerId, Currency currency, String socialRefresh, Token token, Role role) {
+    public User(String email, String name, String profileImageUrl, Provider provider, String providerId, Currency currency, String socialRefresh, Role role) {
         this.email = email;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
@@ -64,7 +59,6 @@ public class User extends BaseTimeEntity {
         this.currency = currency;
         this.socialRefresh = socialRefresh;
         this.role = role;
-        this.token = token;
     }
 
     public static User createKakaoUserBuilder(KakaoUserDto kakaoUser, String socialRefreshToken) {

--- a/src/main/java/com/joojoo/api/user/domain/model/entity/User.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/entity/User.java
@@ -50,6 +50,7 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private Role role;
 
+    // 이거 양방향 할 필요가 없는거 같아서 기능 구현후 삭제 할 예정
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
     private Token token;
 
@@ -109,5 +110,13 @@ public class User extends BaseTimeEntity {
         if (!Role.ADMIN.equals(this.role)) {
             throw new AdminOnlyAccessException();
         }
+    }
+
+    public void updateName(String newName) {
+        this.name = newName;
+    }
+
+    public void updateProfileImage(String fileName) {
+        this.profileImageUrl = fileName;
     }
 }

--- a/src/main/java/com/joojoo/api/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/joojoo/api/user/domain/repository/UserRepository.java
@@ -10,4 +10,5 @@ public interface UserRepository {
     Optional<User> findByProviderId(String providerId);
     Optional<User> findById(Long userId);
     void delete(User user);
+    boolean existsByName(String nickname);
 }

--- a/src/main/java/com/joojoo/api/user/infrastructure/rdbms/UserJpaRepository.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/rdbms/UserJpaRepository.java
@@ -12,4 +12,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByProviderId(String providerId);
+
+    boolean existsUserByName(String name);
 }

--- a/src/main/java/com/joojoo/api/user/infrastructure/rdbms/UserRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/rdbms/UserRepositoryImpl.java
@@ -37,4 +37,9 @@ public class UserRepositoryImpl implements UserRepository {
     public void delete(User user) {
         userJpaRepository.delete(user);
     }
+
+    @Override
+    public boolean existsByName(String nickname) {
+        return userJpaRepository.existsUserByName(nickname);
+    }
 }

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -4,8 +4,10 @@ import com.joojoo.api.user.application.UserService;
 import com.joojoo.api.user.application.auth.AuthSocialService;
 import com.joojoo.api.user.presentation.dto.request.AuthCodeDto;
 import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
+import com.joojoo.api.user.presentation.dto.request.UpdateProfileDto;
 import com.joojoo.api.user.presentation.dto.response.DefaultProfileImageResponse;
 import com.joojoo.api.user.presentation.dto.response.LoginResponse;
+import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
 import com.joojoo.global.common.request.auth.CustomUserDetails;
 import com.joojoo.global.common.response.BaseResponse;
 import com.joojoo.global.common.response.ErrorResponse;
@@ -104,6 +106,27 @@ public class UserController {
     @GetMapping("/profile-images/default")
     public BaseResponse<DefaultProfileImageResponse> getDefaultProfileImages(){
         return BaseResponse.ok(userService.getDefaultProfileImages());
+    }
+
+    @Operation(summary = "프로필 업데이트 API", description = "기본 프로필 이미지 또는 이름을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "업데이트 성공"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임입니다.",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없습니다.",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    @PatchMapping("/profile")
+    public BaseResponse<UserInfoResponse> updateProfile(@AuthenticationPrincipal CustomUserDetails user,
+                                                        @RequestBody UpdateProfileDto updateProfileDto
+    ){
+        return BaseResponse.ok(userService.updateProfile(user.getUserId(), updateProfileDto));
     }
 
 }

--- a/src/main/java/com/joojoo/api/user/presentation/dto/request/UpdateProfileDto.java
+++ b/src/main/java/com/joojoo/api/user/presentation/dto/request/UpdateProfileDto.java
@@ -1,0 +1,12 @@
+package com.joojoo.api.user.presentation.dto.request;
+
+import com.joojoo.api.user.domain.model.enums.DefaultProfileImage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateProfileDto {
+    private String name;
+    private DefaultProfileImage profile;
+}

--- a/src/main/java/com/joojoo/api/user/presentation/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/joojoo/api/user/presentation/dto/response/UserInfoResponse.java
@@ -1,0 +1,26 @@
+package com.joojoo.api.user.presentation.dto.response;
+
+import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.api.user.domain.model.enums.Currency;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class UserInfoResponse {
+    private Long id;
+    private String name;
+    private String profileUrl;
+    private Currency currency;
+
+    public static UserInfoResponse of(User user, String fullProfileUrl){
+        return UserInfoResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .profileUrl(fullProfileUrl)
+                .currency(user.getCurrency())
+                .build();
+    }
+}

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
     EMAIL_ALREADY_IN_USE(409, "USER_EMAIL_DUPLICATED", "이미 사용 중인 이메일입니다."),
     USER_MISMATCH(403, "USER_MISMATCH", "회원 정보가 일치하지 않습니다."),
     ADMIN_ONLY(403, "ADMIN_ONLY", "관리자 권한이 필요합니다."),
+    USER_NAME_REQUIRED(400, "USER_NAME_REQUIRED", "초기 설정 시 닉네임은 필수입니다."),
+    USER_NAME_DUPLICATED(409, "USER_NAME_DUPLICATED", "이미 사용 중인 닉네임입니다."),
 
     // ───────────────────────────── 인증/인가(auth) ─────────────────────────────
     INVALID_AUTHORIZATION_CODE(400, "INVALID_AUTHORIZATION_CODE", "유효하지 않은 인가 코드입니다."),

--- a/src/main/java/com/joojoo/global/exception/handleException/users/UserNameDuplicatedException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/users/UserNameDuplicatedException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.users;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class UserNameDuplicatedException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.USER_NAME_DUPLICATED;
+
+    public UserNameDuplicatedException() {
+        super(errorCode);
+    }
+
+    public UserNameDuplicatedException(Exception exception) {
+        super(errorCode, exception);
+    }
+}

--- a/src/main/java/com/joojoo/global/exception/handleException/users/UserNameRequiredException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/users/UserNameRequiredException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.users;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class UserNameRequiredException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.USER_NAME_REQUIRED;
+
+    public UserNameRequiredException() {
+        super(errorCode);
+    }
+
+    public UserNameRequiredException(Exception exception) {
+        super(errorCode, exception);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 회원 프로필 설정 및 수정 비즈니스 로직 구현

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

회원가입 후 초기 프로필 설정 및 이후 마이페이지에서의 프로필 수정 기능을 처리하는 서비스 로직을 구현했습니다. 하나의 API로 초기 설정과 수정을 모두 처리할 수 있도록, 입력값에 따른 동적 업데이트 및 검증 로직을 적용했습니다.

User 엔티티와 Token 엔티티 간의 불필요한 양방향 매핑(`@OneToOne`)을 끊고 단방향으로 리팩토링하였습니다.
기존 구조에서는 User 정보를 조회할 때마다 연관된 Token 정보 유무를 확인하기 위해 불필요한 쿼리가 실행되는 문제(N+1)가 있었습니다.
이를 해결하기 위해 User 엔티티에서 Token 필드를 제거하고, 토큰 갱신이 필요한 로그인 시점에만 `TokenRepository`를 통해 명시적으로 조회하도록 로직을 변경하였습니다.

---

## 작업 내용

- 프로필 수정 메인 로직 구현 (`updateProfile`)
- 닉네임 검증 및 업데이트 (`validateAndUpdateName`)
  - 변경 요청된 이름이 존재할 경우, 기존 이름과 다르면 중복 검사를 수행합니다.
  - 요청 값이 null일 때, 기존 유저의 이름도 null(최초 가입자)이라면 `UserNameRequiredException` 예외를 발생시켜 필수 입력을 강제합니다.
- 프로필 이미지 처리 (`updateOrInitProfileImage`)
  - 사용자가 선택한 이미지가 있다면 해당 이미지로 업데이트합니다.
  - 사용자가 이미지를 선택하지 않았고(null), 기존 프로필 이미지도 없는 경우(최초 설정)에는 **기본 이미지(PROFILE_1)** 를 자동으로 설정합니다.
- **User-Token 양방향 매핑 제거 (단방향 전환)**
  - `User` 엔티티 내 `token` 필드 삭제
  - User 조회 시 불필요한 Token 조회가 동반되는 성능 이슈 해결 (Lazy Loading 미적용 문제 해결)
- **토큰 갱신 로직 수정 (`registerRefreshToken`)**
  - 연관관계 제거에 따라 객체 참조(`user.getToken()`) 방식 불가
  - `TokenRepository.findByUserId`를 통한 명시적 DB 조회 방식으로 변경

---

## 관련 이슈

