### PR TITLE
feat: 블럭(노트) 트리 구조 저장 및 생성 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockService.java
@@ -1,0 +1,8 @@
+package com.joojoo.api.block.application;
+
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+
+public interface BlockService {
+    BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto);
+}

--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -1,0 +1,57 @@
+package com.joojoo.api.block.application;
+
+import com.joojoo.api.block.application.validate.blockerTree.BlockTreeValidator;
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.domain.repository.BlockRepository;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponseDto;
+import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.api.user.domain.repository.UserRepository;
+import com.joojoo.global.exception.handleException.users.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BlockServiceImpl implements BlockService {
+
+    private final BlockRepository blockRepository;
+    private final UserRepository userRepository;
+    private final BlockTreeValidator blockTreeValidator;
+
+    @Override
+    @Transactional
+    public BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto) {
+        blockTreeValidator.validateStructure(requestDto);
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        List<BlockResponseDto> savedTree = saveBlocksRecursive(user, null, requestDto.getBlocks());
+        return BlockResponse.of(savedTree);
+    }
+
+    private List<BlockResponseDto> saveBlocksRecursive(User user, Block parentBlock, List<BlockRequestDto> blockDtos) {
+        if (blockDtos == null || blockDtos.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<BlockResponseDto> responseList = new ArrayList<>();
+
+        for (BlockRequestDto dto : blockDtos) {
+            Block block = Block.createBlockBuild(user, parentBlock, dto);
+            Block savedBlock = blockRepository.save(block);
+
+            // 자식 재귀 호출, 없으면 빈 List 반환
+            List<BlockResponseDto> childrenResponse = saveBlocksRecursive(user, savedBlock, dto.getChildren());
+            BlockResponseDto responseDto = BlockResponseDto.of(savedBlock, childrenResponse);
+            responseList.add(responseDto);
+        }
+        return responseList;
+    }
+
+}

--- a/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidator.java
+++ b/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidator.java
@@ -1,0 +1,7 @@
+package com.joojoo.api.block.application.validate.blockerTree;
+
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+
+public interface BlockTreeValidator {
+    void validateStructure(BlockSaveRequestDto requestDto);
+}

--- a/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidatorImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidatorImpl.java
@@ -1,0 +1,41 @@
+package com.joojoo.api.block.application.validate.blockerTree;
+
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.global.exception.enums.ErrorCode;
+import com.joojoo.global.exception.handleException.block.InvalidBlockStructureException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BlockTreeValidatorImpl implements BlockTreeValidator {
+
+    public static final int MAX_DEPTH = 2;
+
+    @Override
+    public void validateStructure(BlockSaveRequestDto requestDto) {
+        if (requestDto.getBlocks() == null || requestDto.getBlocks().size() != 1) {
+            throw new InvalidBlockStructureException(ErrorCode.INVALID_ROOT_BLOCK_COUNT);
+        }
+
+        validateDepth(requestDto.getBlocks().get(0), 0);
+    }
+
+    private void validateDepth(BlockRequestDto block, int currentDepth) {
+        if (currentDepth == MAX_DEPTH) {
+            if (block.getChildren() != null && !block.getChildren().isEmpty()) {
+                throw new InvalidBlockStructureException(ErrorCode.MAX_BLOCK_DEPTH_EXCEEDED);
+            }
+            return;
+        }
+
+        if (currentDepth > MAX_DEPTH) {
+            throw new InvalidBlockStructureException(ErrorCode.MAX_BLOCK_DEPTH_EXCEEDED);
+        }
+
+        if (block.getChildren() != null) {
+            for (BlockRequestDto child : block.getChildren()) {
+                validateDepth(child, currentDepth + 1);
+            }
+        }
+    }
+}

--- a/src/main/java/com/joojoo/api/block/domain/model/entity/Block.java
+++ b/src/main/java/com/joojoo/api/block/domain/model/entity/Block.java
@@ -1,7 +1,7 @@
 package com.joojoo.api.block.domain.model.entity;
 
 import com.joojoo.api.block.domain.model.enums.BlockType;
-import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -33,10 +33,6 @@ public class Block extends BaseTimeEntity {
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
     private List<Block> children = new ArrayList<>();
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "template_id")
-    private TradeLog tradeLog;
-
     @Column(columnDefinition = "TEXT")
     private String content;
 
@@ -48,18 +44,32 @@ public class Block extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private BlockType type;
+    @JoinColumn(name = "block_type")
+    private BlockType blockType;
 
     @Column(name = "is_saved", nullable = false)
-    private Boolean isSaved = false;
+    private Boolean isSaved;
 
     @Builder
-    public Block(User user, Block parent, String content, Integer depth, Integer sequence, BlockType type) {
+    public Block(User user, Block parent, String content, Integer depth, Integer sequence, BlockType blockType, Boolean isSaved) {
         this.user = user;
         this.parent = parent;
         this.content = content;
         this.depth = depth;
         this.sequence = sequence;
-        this.type = type;
+        this.blockType = blockType;
+        this.isSaved = (isSaved != null) ? isSaved : false;
+    }
+
+    public static Block createBlockBuild(User user, Block parentBlock, BlockRequestDto dto){
+        return Block.builder()
+                .user(user)
+                .parent(parentBlock)
+                .content(dto.getContent())
+                .blockType(BlockType.valueOf(dto.getBlockType().getText()))
+                .depth(dto.getDepth())
+                .sequence(dto.getSequence())
+                .isSaved(dto.getIsSaved())
+                .build();
     }
 }

--- a/src/main/java/com/joojoo/api/block/domain/model/enums/BlockType.java
+++ b/src/main/java/com/joojoo/api/block/domain/model/enums/BlockType.java
@@ -6,9 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum BlockType {
-    TEXT("글"),
-    IMAGE("이미지"),
-    TRADE("거래 정보"),
+    TEXT("TEXT"),
+    IMAGE("IMAGE"),
     ;
 
     private final String text;

--- a/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
+++ b/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
@@ -1,0 +1,7 @@
+package com.joojoo.api.block.domain.repository;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+
+public interface BlockRepository {
+    Block save(Block block);
+}

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockJpaRepository.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockJpaRepository.java
@@ -1,0 +1,9 @@
+package com.joojoo.api.block.infrastructure.rdbms;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlockJpaRepository extends JpaRepository<Block, Long> {
+}

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.joojoo.api.block.infrastructure.rdbms;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.domain.repository.BlockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockRepositoryImpl implements BlockRepository {
+
+    private final BlockJpaRepository blockJpaRepository;
+
+    @Override
+    public Block save(Block block) {
+        return blockJpaRepository.save(block);
+    }
+}

--- a/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
+++ b/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
@@ -1,0 +1,51 @@
+package com.joojoo.api.block.presentation.controller;
+
+import com.joojoo.api.block.application.BlockService;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+import com.joojoo.global.common.request.auth.CustomUserDetails;
+import com.joojoo.global.common.response.BaseResponse;
+import com.joojoo.global.common.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Block API", description = "블럭(노트) 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("block")
+public class BlockController {
+
+    private final BlockService blockService;
+
+    @Operation(summary = "블럭(노트) 생성 API", description = "사용자가 작성한 블럭(노트) 트리 구조를 받아 저장합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "저장 성공",
+                    content = @Content(schema = @Schema(implementation = BlockResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 블럭 구조 (Ex. 루트 개수 오류, Depth 초과)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/create-blocks")
+    public BaseResponse<BlockResponse> createBlock(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody BlockSaveRequestDto requestDto
+    ) {
+        return BaseResponse.ok(blockService.saveBlockTree(user.getUserId(), requestDto));
+    }
+
+}

--- a/src/main/java/com/joojoo/api/block/presentation/dto/request/createBlock/BlockRequestDto.java
+++ b/src/main/java/com/joojoo/api/block/presentation/dto/request/createBlock/BlockRequestDto.java
@@ -1,0 +1,18 @@
+package com.joojoo.api.block.presentation.dto.request.createBlock;
+
+import com.joojoo.api.block.domain.model.enums.BlockType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BlockRequestDto {
+    private String content;
+    private BlockType blockType;
+    private Integer depth;
+    private Integer sequence;
+    private Boolean isSaved;
+    private List<BlockRequestDto> children;
+}

--- a/src/main/java/com/joojoo/api/block/presentation/dto/request/createBlock/BlockSaveRequestDto.java
+++ b/src/main/java/com/joojoo/api/block/presentation/dto/request/createBlock/BlockSaveRequestDto.java
@@ -1,0 +1,12 @@
+package com.joojoo.api.block.presentation.dto.request.createBlock;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BlockSaveRequestDto {
+    private List<BlockRequestDto> blocks;
+}

--- a/src/main/java/com/joojoo/api/block/presentation/dto/response/blockDetail/BlockResponse.java
+++ b/src/main/java/com/joojoo/api/block/presentation/dto/response/blockDetail/BlockResponse.java
@@ -1,0 +1,16 @@
+package com.joojoo.api.block.presentation.dto.response.blockDetail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BlockResponse {
+    private List<BlockResponseDto> blockList;
+
+    public static BlockResponse of(List<BlockResponseDto> blocks) {
+        return new BlockResponse(blocks);
+    }
+}

--- a/src/main/java/com/joojoo/api/block/presentation/dto/response/blockDetail/BlockResponseDto.java
+++ b/src/main/java/com/joojoo/api/block/presentation/dto/response/blockDetail/BlockResponseDto.java
@@ -1,0 +1,31 @@
+package com.joojoo.api.block.presentation.dto.response.blockDetail;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class BlockResponseDto {
+    private Long blockId;
+    private String content;
+    private String blockType;
+    private Integer depth;
+    private Integer sequence;
+    private List<BlockResponseDto> children;
+
+    public static BlockResponseDto of(Block block, List<BlockResponseDto> children) {
+        return BlockResponseDto.builder()
+                .blockId(block.getId())
+                .content(block.getContent())
+                .blockType(block.getBlockType().name())
+                .depth(block.getDepth())
+                .sequence(block.getSequence())
+                .children(children)
+                .build();
+    }
+}

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -45,6 +45,10 @@ public enum ErrorCode {
     // ---------------------------- 티커 (Ticker) ----------------------------
     INVALID_TICKER_NAME(401, "INVALID_TICKER_NAME", "티커 또는 이름을 작성하세요."),
 
+    //---------------------------- 블럭 (Block) ----------------------------
+    INVALID_ROOT_BLOCK_COUNT(400, "INVALID_ROOT_BLOCK_COUNT", "최상위 블록(부모)은 반드시 1개여야 합니다."),
+    MAX_BLOCK_DEPTH_EXCEEDED(400, "MAX_BLOCK_DEPTH_EXCEEDED", "블록 계층은 최대 2단계(Depth 2)까지만 허용됩니다."),
+
     ;
 
     private final int httpStatus;

--- a/src/main/java/com/joojoo/global/exception/handleException/block/InvalidBlockStructureException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/block/InvalidBlockStructureException.java
@@ -1,0 +1,11 @@
+package com.joojoo.global.exception.handleException.block;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class InvalidBlockStructureException extends ServiceException {
+
+    public InvalidBlockStructureException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 블럭(노트) 트리 구조 저장 및 생성 API 구현

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [ ] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

사용자가 작성한 **계층형 구조(트리)** 의 블럭 데이터를 DB에 저장하는 API를 구현했습니다.
다중 깊이(Depth)를 가진 데이터를 처리하기 위해 **DFS 기반의 재귀 호출** 방식을 사용하였으며, 비즈니스 규칙에 따른 구조 검증 로직을 포함하고 있습니다.

---

## 작업 내용

**1. 블럭 트리 저장 비즈니스 로직 구현 (`BlockService`)**
- **재귀적 저장(Recursive Save):** `saveBlocksRecursive` 메서드를 구현하여 부모 블럭을 먼저 저장하고, 생성된 `Parent ID`를 자식 블럭에게 전달하는 방식으로 연관관계를 맺었습니다.
- **스택 기반 응답 조립:** 재귀 호출이 종료되고 스택이 풀리는(Unwinding) 과정에서, 저장된 자식 노드들의 리스트를 부모 DTO에 조립하여 **전체 트리 구조를 한 번에 반환** 하도록 구현했습니다.

**2. 블럭 구조 유효성 검증 (`BlockTreeValidator`)**
- 비즈니스 규칙 준수를 위한 사전 검증 로직을 추가했습니다.
  - **Root 개수 제한:** 최상위 부모 블럭은 반드시 1개여야 합니다.
  - **Depth 제한:** 블럭의 깊이는 최대 2(Depth 0~2)까지만 허용됩니다.

**3. 커스텀 예외 처리 및 ErrorCode 정의**
- 구조 검증 실패 시 명확한 사유를 전달하기 위해 `InvalidBlockStructureException`을 구현했습니다.
- 에러 상황을 세분화하여 Enum으로 관리합니다.
  - `INVALID_ROOT_BLOCK_COUNT`: 루트 블럭 개수 오류
  - `MAX_BLOCK_DEPTH_EXCEEDED`: 허용 깊이 초과

---

## 관련 이슈

- #19 