### PR TITLE
feat: 블록 내 키워드(티커/태그) 자동 파싱 및 트리 구조 저장 기능 구현

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -1,11 +1,13 @@
 package com.joojoo.api.block.application;
 
+import com.joojoo.api.block.application.metadata.MetadataService;
 import com.joojoo.api.block.application.validate.blockerTree.BlockTreeValidator;
 import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponseDto;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
 import com.joojoo.global.exception.handleException.users.UserNotFoundException;
@@ -16,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -25,6 +29,7 @@ public class BlockServiceImpl implements BlockService {
     private final BlockRepository blockRepository;
     private final UserRepository userRepository;
     private final BlockTreeValidator blockTreeValidator;
+    private final MetadataService metadataService;
 
     @Override
     @Transactional
@@ -32,14 +37,43 @@ public class BlockServiceImpl implements BlockService {
         blockTreeValidator.validateStructure(requestDto);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
-        // 벌크 처리를 위한 Block 저장소
-        List<Block> allBlocks = new ArrayList<>();
-        blocksRecursive(user, null, requestDto.getBlocks(), allBlocks);
-        // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중
-        blockRepository.saveAll(allBlocks);
-        log.info("allBlocks = {}", allBlocks);
+        // 블록 엔티티 저장
+        List<Block> allBlocks = createAndSaveBlocks(user, requestDto.getBlocks());
+        BlockResponse blockResponse = reconstructBlockTree(allBlocks);
 
-        return BlockResponse.of(null);
+        metadataService.processMetadata(allBlocks);
+        return blockResponse;
+    }
+
+    /** 리스트에 블럭을 담아 한번에 저장하는 메서드 */
+    private List<Block> createAndSaveBlocks(User user, List<BlockRequestDto> dtos) {
+        List<Block> allBlocks = new ArrayList<>();
+        blocksRecursive(user, null, dtos, allBlocks);
+        return blockRepository.saveAll(allBlocks); // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중
+    }
+
+    /** List에서 다시 트리 형식으로 변환 */
+    private BlockResponse reconstructBlockTree(List<Block> blocks) {
+        // ID를 키로 하는 DTO Map 생성
+        Map<Long, BlockResponseDto> dtoMap = blocks.stream()
+                .map(block -> BlockResponseDto.of(block, new ArrayList<>()))
+                .collect(Collectors.toMap(BlockResponseDto::getBlockId, dto -> dto));
+
+        // 부모-자식 연결 및 루트 블록 추출
+        List<BlockResponseDto> rootBlocks = new ArrayList<>();
+        for (Block block : blocks) {
+            BlockResponseDto currentDto = dtoMap.get(block.getId());
+
+            if (block.getParent() == null) {
+                rootBlocks.add(currentDto);
+            } else {
+                BlockResponseDto parentDto = dtoMap.get(block.getParent().getId());
+                if (parentDto != null) {
+                    parentDto.getChildren().add(currentDto);
+                }
+            }
+        }
+        return BlockResponse.of(rootBlocks);
     }
 
     /** RequestDto를 순회하며 JPA 엔티티(Block)를 생성하고, allBlocks에 수집하는 메서드 */
@@ -48,7 +82,7 @@ public class BlockServiceImpl implements BlockService {
 
         for (BlockRequestDto dto : blockDtos) {
             Block block = Block.createBlockBuild(user, parentBlock, dto);
-            allBlocks.add(block); // 벌크 처리할려고 담기
+            allBlocks.add(block);
             blocksRecursive(user, block, dto.getChildren(), allBlocks); // 자식 재귀 호출
         }
     }

--- a/src/main/java/com/joojoo/api/block/application/metadata/MetadataService.java
+++ b/src/main/java/com/joojoo/api/block/application/metadata/MetadataService.java
@@ -1,0 +1,20 @@
+package com.joojoo.api.block.application.metadata;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.request.metadata.MatchedMetadataDto;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.tag.domain.model.entity.Tag;
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface MetadataService {
+    Map<Block, List<MatchedMetadataDto>> scanBlocks(List<Block> allBlocks, Set<String> tickerNames, Set<String> tagNames);
+
+    void mapToEntities(Block block, List<MatchedMetadataDto> matches, Map<String, Ticker> tickerMap, Map<String, Tag> tagMap, List<BlockTicker> blockTickers, List<BlockTag> blockTags);
+
+    void processMetadata(List<Block> allBlocks);
+}

--- a/src/main/java/com/joojoo/api/block/application/metadata/MetadataServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/metadata/MetadataServiceImpl.java
@@ -1,0 +1,108 @@
+package com.joojoo.api.block.application.metadata;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.request.metadata.MatchedMetadataDto;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
+import com.joojoo.api.tag.application.in.TagInService;
+import com.joojoo.api.tag.domain.model.entity.Tag;
+import com.joojoo.api.ticker.application.in.TickerInService;
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class MetadataServiceImpl implements MetadataService {
+
+    private static final Pattern COMBINED_PATTERN = Pattern.compile("\\$([a-zA-Z0-9가-힣.-]+)|#([^\\s#]+)");
+
+    private final TagInService tagInService;
+    private final TickerInService tickerInService;
+
+    private final BlockTickerRepository blockTickerRepository;
+    private final BlockTagRepository blockTagRepository;
+
+    @Override
+    public void processMetadata(List<Block> blocks) {
+        // 정규식 메타데이버 검사
+        Set<String> tickerNames = new HashSet<>();
+        Set<String> tagNames = new HashSet<>();
+        Map<Block, List<MatchedMetadataDto>> analysisMap = scanBlocks(blocks, tickerNames, tagNames);
+
+        // Ticker, Tag Entity 준비
+        Map<String, Ticker> tickerMap = tickerInService.getTickerMap(tickerNames);
+        Map<String, Tag> tagMap = tagInService.getOrCreateTagMap(tagNames);
+
+        // 연관관계 엔티티 생성
+        List<BlockTicker> blockTickers = new ArrayList<>();
+        List<BlockTag> blockTags = new ArrayList<>();
+
+        for (Block block : blocks) {
+            List<MatchedMetadataDto> matches = analysisMap.getOrDefault(block, Collections.emptyList());
+            mapToEntities(block, matches, tickerMap, tagMap, blockTickers, blockTags);
+        }
+
+        // TODO : JDBC Batch Insert 고려, 지금 중간 테이블이 10개면 10개의 Insert 쿼리 작동 중
+        blockTickerRepository.saveAll(blockTickers);
+        blockTagRepository.saveAll(blockTags);
+    }
+
+    /** Block.content을 읽어 Ticker, Tag를 찾아서 담기 */
+    @Override
+    public Map<Block, List<MatchedMetadataDto>> scanBlocks(List<Block> blocks, Set<String> tickerNames, Set<String> tagNames) {
+        Map<Block, List<MatchedMetadataDto>> analysisResult = new HashMap<>();
+
+        for (Block block : blocks) {
+            String content = block.getContent();
+            if (content == null || content.isEmpty()) continue;
+
+            List<MatchedMetadataDto> matches = new ArrayList<>();
+            Matcher matcher = COMBINED_PATTERN.matcher(content);
+
+            while (matcher.find()) {
+                if (matcher.group(1) != null) { // 티커
+                    String name = matcher.group(1);
+                    tickerNames.add(name);
+                    matches.add(new MatchedMetadataDto(name, matcher.start(), true));
+                } else if (matcher.group(2) != null) { // 태그
+                    String name = matcher.group(2);
+                    tagNames.add(name);
+                    matches.add(new MatchedMetadataDto(name, matcher.start(), false));
+                }
+            }
+            analysisResult.put(block, matches);
+        }
+        return analysisResult;
+    }
+
+    /** 추출된 맵을 바탕으로 BlockTicker, BlockTag 중간 테이블 엔티티 생성 */
+    @Override
+    public void mapToEntities(Block block, List<MatchedMetadataDto> matches, Map<String, Ticker> tickerMap, Map<String, Tag> tagMap, List<BlockTicker> bTickers, List<BlockTag> bTags) {
+        if (block.getContent() == null) return;
+
+        AtomicInteger tSeq = new AtomicInteger();
+        AtomicInteger tagSeq = new AtomicInteger();
+
+        for (MatchedMetadataDto match : matches) {
+            if (match.isTicker()) {
+                Optional.ofNullable(tickerMap.get(match.name()))
+                        .ifPresent(t -> bTickers.add(BlockTicker.create(block, t, match.start(), tSeq.getAndIncrement())));
+            } else {
+                Optional.ofNullable(tagMap.get(match.name()))
+                        .ifPresent(tag -> bTags.add(BlockTag.create(block, tag, match.start(), tagSeq.getAndIncrement())));
+            }
+        }
+    }
+
+
+
+
+}

--- a/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
+++ b/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface BlockRepository {
     Block save(Block block);
 
-    void saveAll(List<Block> allBlocks);
+    List<Block> saveAll(List<Block> allBlocks);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
@@ -19,7 +19,7 @@ public class BlockRepositoryImpl implements BlockRepository {
     }
 
     @Override
-    public void saveAll(List<Block> allBlocks) {
-        blockJpaRepository.saveAll(allBlocks);
+    public List<Block> saveAll(List<Block> allBlocks) {
+        return blockJpaRepository.saveAll(allBlocks);
     }
 }

--- a/src/main/java/com/joojoo/api/block/presentation/dto/request/metadata/MatchedMetadataDto.java
+++ b/src/main/java/com/joojoo/api/block/presentation/dto/request/metadata/MatchedMetadataDto.java
@@ -1,0 +1,4 @@
+package com.joojoo.api.block.presentation.dto.request.metadata;
+
+public record MatchedMetadataDto(String name, int start, boolean isTicker) {
+}

--- a/src/main/java/com/joojoo/api/blockTag/domain/model/entity/BlockTag.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/model/entity/BlockTag.java
@@ -48,4 +48,13 @@ public class BlockTag extends BaseCreateEntity {
         this.sequence = sequence;
         this.startOffset = startOffset;
     }
+
+    public static BlockTag create(Block block, Tag tag, int start, int tagSeq) {
+        return BlockTag.builder()
+                .block(block)
+                .tag(tag)
+                .sequence(tagSeq)
+                .startOffset(start)
+                .build();
+    }
 }

--- a/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
@@ -1,4 +1,9 @@
 package com.joojoo.api.blockTag.domain.repository;
 
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+
+import java.util.List;
+
 public interface BlockTagRepository {
+    List<BlockTag> saveAll(List<BlockTag> blockTags);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.joojoo.api.blockTag.infrastructure.rdbms;
 
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -11,4 +14,8 @@ public class BlockTagRepositoryImpl implements BlockTagRepository {
     private final BlockTagJpaRepository blockTagJpaRepository;
 
 
+    @Override
+    public List<BlockTag> saveAll(List<BlockTag> blockTags) {
+        return blockTagJpaRepository.saveAll(blockTags);
+    }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/domain/model/entity/BlockTicker.java
+++ b/src/main/java/com/joojoo/api/blockTicker/domain/model/entity/BlockTicker.java
@@ -9,9 +9,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -47,5 +44,14 @@ public class BlockTicker extends BaseCreateEntity {
         this.tradeLog = tradeLog;
         this.sequence = sequence;
         this.startOffset = startOffset;
+    }
+
+    public static BlockTicker create(Block block, Ticker ticker, int start, int tSeq) {
+        return BlockTicker.builder()
+                .block(block)
+                .ticker(ticker)
+                .sequence(tSeq)
+                .startOffset(start)
+                .build();
     }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/domain/repository/BlockTickerRepository.java
+++ b/src/main/java/com/joojoo/api/blockTicker/domain/repository/BlockTickerRepository.java
@@ -1,4 +1,9 @@
 package com.joojoo.api.blockTicker.domain.repository;
 
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+
+import java.util.List;
+
 public interface BlockTickerRepository {
+    List<BlockTicker> saveAll(List<BlockTicker> blockTickers);
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
@@ -1,12 +1,20 @@
 package com.joojoo.api.blockTicker.infrastructure.rdbms;
 
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class BlockTickerRepositoryImpl implements BlockTickerRepository {
 
     private final BlockTickerJpaRepository blockTickerJpaRepository;
+
+    @Override
+    public List<BlockTicker> saveAll(List<BlockTicker> blockTickers) {
+        return blockTickerJpaRepository.saveAll(blockTickers);
+    }
 }

--- a/src/main/java/com/joojoo/api/tag/application/in/TagInService.java
+++ b/src/main/java/com/joojoo/api/tag/application/in/TagInService.java
@@ -1,0 +1,10 @@
+package com.joojoo.api.tag.application.in;
+
+import com.joojoo.api.tag.domain.model.entity.Tag;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface TagInService {
+    Map<String, Tag> getOrCreateTagMap(Set<String> tagNames);
+}

--- a/src/main/java/com/joojoo/api/tag/application/in/TagInServiceImpl.java
+++ b/src/main/java/com/joojoo/api/tag/application/in/TagInServiceImpl.java
@@ -1,0 +1,50 @@
+package com.joojoo.api.tag.application.in;
+
+import com.joojoo.api.tag.domain.model.entity.Tag;
+import com.joojoo.api.tag.domain.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TagInServiceImpl implements TagInService {
+
+    private final TagRepository tagRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Tag> getOrCreateTagMap(Set<String> names) {
+        if (names.isEmpty()) return Collections.emptyMap();
+
+        List<Tag> existing = tagRepository.findAllByNames(names);
+        Map<String, Tag> tagMap = getTagMap(existing);
+        List<Tag> newTags = getNewTags(names, tagMap);
+
+        if (!newTags.isEmpty()) {
+            tagRepository.saveAll(newTags)
+                    .forEach(t -> tagMap.put(t.getName(), t));
+        }
+        return tagMap;
+    }
+
+    private static Map<String, Tag> getTagMap(List<Tag> existing) {
+        return existing.stream()
+                .collect(Collectors.toMap(Tag::getName, t -> t));
+    }
+
+    private static List<Tag> getNewTags(Set<String> names, Map<String, Tag> tagMap) {
+        return names.stream()
+                .filter(name -> !tagMap.containsKey(name))
+                .map(name -> Tag.builder().name(name).build())
+                .toList();
+    }
+
+
+}

--- a/src/main/java/com/joojoo/api/tag/infrastructure/queryDsl/TagQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/tag/infrastructure/queryDsl/TagQueryDslRepository.java
@@ -1,13 +1,10 @@
-package com.joojoo.api.tag.domain.repository;
+package com.joojoo.api.tag.infrastructure.queryDsl;
 
 import com.joojoo.api.tag.domain.model.entity.Tag;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-public interface TagRepository {
+public interface TagQueryDslRepository {
     List<Tag> findAllByNames(Set<String> names);
-
-    List<Tag> saveAll(List<Tag> newTags);
 }

--- a/src/main/java/com/joojoo/api/tag/infrastructure/queryDsl/TagQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tag/infrastructure/queryDsl/TagQueryDslRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.joojoo.api.tag.infrastructure.queryDsl;
+
+import com.joojoo.api.tag.domain.model.entity.QTag;
+import com.joojoo.api.tag.domain.model.entity.Tag;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class TagQueryDslRepositoryImpl implements TagQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QTag tag = QTag.tag;
+
+    @Override
+    public List<Tag> findAllByNames(Set<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return queryFactory
+                .selectFrom(tag)
+                .where(tag.name.in(names))
+                .fetch();
+    }
+}

--- a/src/main/java/com/joojoo/api/tag/infrastructure/rdbms/TagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tag/infrastructure/rdbms/TagRepositoryImpl.java
@@ -1,12 +1,28 @@
 package com.joojoo.api.tag.infrastructure.rdbms;
 
+import com.joojoo.api.tag.domain.model.entity.Tag;
 import com.joojoo.api.tag.domain.repository.TagRepository;
+import com.joojoo.api.tag.infrastructure.queryDsl.TagQueryDslRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
 public class TagRepositoryImpl implements TagRepository {
 
     private final TagJpaRepository tagJpaRepository;
+    private final TagQueryDslRepository tagQueryDslRepository;
+
+    @Override
+    public List<Tag> findAllByNames(Set<String> names) {
+        return tagQueryDslRepository.findAllByNames(names);
+    }
+
+    @Override
+    public List<Tag> saveAll(List<Tag> newTags) {
+         return tagJpaRepository.saveAll(newTags);
+    }
 }

--- a/src/main/java/com/joojoo/api/ticker/application/in/TickerInService.java
+++ b/src/main/java/com/joojoo/api/ticker/application/in/TickerInService.java
@@ -1,0 +1,10 @@
+package com.joojoo.api.ticker.application.in;
+
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface TickerInService {
+    Map<String, Ticker> getTickerMap(Set<String> tickerNames);
+}

--- a/src/main/java/com/joojoo/api/ticker/application/in/TickerInServiceImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/application/in/TickerInServiceImpl.java
@@ -1,0 +1,27 @@
+package com.joojoo.api.ticker.application.in;
+
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import com.joojoo.api.ticker.domain.repository.TickerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TickerInServiceImpl implements TickerInService {
+
+    private final TickerRepository tickerRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Ticker> getTickerMap(Set<String> names) {
+        if (names.isEmpty()) return Collections.emptyMap();
+        return tickerRepository.findAllByTickerNames(names).stream()
+                .collect(Collectors.toMap(Ticker::getName, t -> t));
+    }
+}

--- a/src/main/java/com/joojoo/api/ticker/domain/model/entity/Ticker.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/model/entity/Ticker.java
@@ -2,13 +2,11 @@ package com.joojoo.api.ticker.domain.model.entity;
 
 import com.joojoo.api.ticker.domain.model.enums.MarketType;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
+@ToString
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/queryDsl/TickerQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/queryDsl/TickerQueryDslRepository.java
@@ -1,14 +1,10 @@
-package com.joojoo.api.ticker.domain.repository;
+package com.joojoo.api.ticker.infrastructure.queryDsl;
 
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 
 import java.util.List;
 import java.util.Set;
 
-public interface TickerRepository {
-    void saveAll(List<Ticker> tickerList);
-
-    List<Ticker> findAll();
-
+public interface TickerQueryDslRepository {
     List<Ticker> findAllByTickerNames(Set<String> tickerSymbols);
 }

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/queryDsl/TickerQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/queryDsl/TickerQueryDslRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.joojoo.api.ticker.infrastructure.queryDsl;
+
+import com.joojoo.api.ticker.domain.model.entity.QTicker;
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class TickerQueryDslRepositoryImpl implements TickerQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QTicker ticker = QTicker.ticker;
+
+    @Override
+    public List<Ticker> findAllByTickerNames(Set<String> symbols) {
+        if (symbols == null || symbols.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return queryFactory
+                .selectFrom(ticker)
+                .where(ticker.name.in(symbols))
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/rdbms/TickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/rdbms/TickerRepositoryImpl.java
@@ -2,17 +2,19 @@ package com.joojoo.api.ticker.infrastructure.rdbms;
 
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.ticker.domain.repository.TickerRepository;
+import com.joojoo.api.ticker.infrastructure.queryDsl.TickerQueryDslRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
 public class TickerRepositoryImpl implements TickerRepository {
 
     private final TickerJpaRepository tickerJpaRepository;
-
+    private final TickerQueryDslRepository tickerQueryDslRepository;
 
     @Override
     public void saveAll(List<Ticker> tickerList) {
@@ -22,5 +24,10 @@ public class TickerRepositoryImpl implements TickerRepository {
     @Override
     public List<Ticker> findAll() {
         return tickerJpaRepository.findAll();
+    }
+
+    @Override
+    public List<Ticker> findAllByTickerNames(Set<String> tickerSymbols) {
+        return tickerQueryDslRepository.findAllByTickerNames(tickerSymbols);
     }
 }

--- a/src/main/java/com/joojoo/global/config/QuerydslConfig.java
+++ b/src/main/java/com/joojoo/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.joojoo.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
- [Feat] 블록 내 키워드(티커/태그) 자동 파싱 및 트리 구조 저장 기능 구현

---

## PR Checklist
- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [x] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요
- 블록 저장 시 텍스트 본문에서 티커(`$`) 및 태그(`#`)를 자동으로 추출(Parsing)하고, 이를 엔티티화하여 블록과 연결하는 기능을 구현했습니다.
- 대량의 블록 트리를 효율적으로 저장하고, 저장된 데이터를 다시 계층 구조로 변환하여 응답하는 로직을 추가했습니다.

---

## 작업 내용
- **재귀적 블록 트리 저장**: `blocksRecursive`를 통해 트리 구조를 순회하며 모든 블록 엔티티를 수집, `saveAll`을 통해 일괄 영속화했습니다.
- **메타데이터 분석 및 매핑 연동**: `MetadataService`를 통해 본문 내 키워드를 스캔하고, `TickerInService`, `TagInService`를 활용해 외부 도메인 엔티티를 조회/생성하여 매핑했습니다.
- **트리 구조 재조립(Reconstruction)**: DB 저장 후 생성된 ID를 바탕으로 메모리 상에서 부모-자식 관계를 복원하여 `BlockResponseDto` 트리 구조를 생성합니다.
- **DDD 기반 서비스 설계**: 타 도메인(Tag, Ticker)의 Repository에 직접 접근하지 않고, `InService` 인터페이스를 통해 협력하도록 설계하여 결합도를 낮췄습니다.

---

## 핵심 로직 및 설계 의도

### 1. 효율적인 트리 변환 알고리즘 ($O(N)$)
리스트 형태의 블록 데이터를 다시 트리로 만들 때, 반복적인 DB 조회를 피하기 위해 `HashMap`을 사용했습니다. 단 한 번의 루프로 전체 계층 구조를 복원합니다.



### 2. 도메인 간 협력 (InService 활용)
`block-parsing` 브랜치의 목적에 맞게, 블록 도메인이 태그와 티커 도메인의 내부 구현에 의존하지 않도록 포트(Port) 역할을 하는 `InService`를 정의하여 사용했습니다. 이는 헥사고날 아키텍처의 의존성 역전 원칙을 지향합니다.

---

## 관련 이슈
