### PR TITLE
feat: 블록 상세 페이지 조회 기능 구현

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockService.java
@@ -2,7 +2,10 @@ package com.joojoo.api.block.application;
 
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 
 public interface BlockService {
     BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto);
+
+    BlockDetailResponseDto getBlockDetail(Long blockId);
 }

--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -1,5 +1,6 @@
 package com.joojoo.api.block.application;
 
+import com.joojoo.api.block.application.detail.BlockDtoAssembler;
 import com.joojoo.api.block.application.metadata.MetadataService;
 import com.joojoo.api.block.application.validate.blockerTree.BlockTreeValidator;
 import com.joojoo.api.block.domain.model.entity.Block;
@@ -8,8 +9,14 @@ import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponseDto;
+import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
+import com.joojoo.global.exception.handleException.block.BlockNotFoundException;
 import com.joojoo.global.exception.handleException.users.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +38,10 @@ public class BlockServiceImpl implements BlockService {
     private final BlockTreeValidator blockTreeValidator;
     private final MetadataService metadataService;
 
+    private final BlockDtoAssembler blockDtoAssembler;
+    private final BlockTagRepository blockTagRepository;
+    private final BlockTickerRepository blockTickerRepository;
+
     @Override
     @Transactional
     public BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto) {
@@ -43,6 +54,19 @@ public class BlockServiceImpl implements BlockService {
 
         metadataService.processMetadata(allBlocks);
         return blockResponse;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BlockDetailResponseDto getBlockDetail(Long rootId) {
+        List<Block> blocks = blockRepository.findAllChildrenByRootId(rootId);
+        if (blocks.isEmpty()) throw new BlockNotFoundException();
+
+        List<Long> ids = blocks.stream().map(Block::getId).toList();
+        List<BlockTag> tags = blockTagRepository.findAllBlockTags(ids);
+        List<BlockTicker> tickers = blockTickerRepository.findAllBlockTickers(ids);
+
+        return blockDtoAssembler.assembleTree(rootId, blocks, tags, tickers);
     }
 
     /** 리스트에 블럭을 담아 한번에 저장하는 메서드 */

--- a/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssembler.java
+++ b/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssembler.java
@@ -1,0 +1,12 @@
+package com.joojoo.api.block.application.detail;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+
+import java.util.List;
+
+public interface BlockDtoAssembler {
+    BlockDetailResponseDto assembleTree(Long rootId, List<Block> blocks, List<BlockTag> tags, List<BlockTicker> tickers);
+}

--- a/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssemblerImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssemblerImpl.java
@@ -1,0 +1,98 @@
+package com.joojoo.api.block.application.detail;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BlockDtoAssemblerImpl implements BlockDtoAssembler {
+
+    @Override
+    public BlockDetailResponseDto assembleTree(Long rootId, List<Block> blocks, List<BlockTag> tags, List<BlockTicker> tickers) {
+        Map<Long, List<BlockDetailResponseDto.MetadataResponse>> tagMap = createMetadataMap(tags,
+                bt -> bt.getBlock().getId(),
+                bt -> createMetadataDto(bt.getTag().getId(), bt.getTag().getName(), bt.getSequence(), bt.getStartOffset()));
+
+        Map<Long, List<BlockDetailResponseDto.MetadataResponse>> tickerMap = createMetadataMap(tickers,
+                bt -> bt.getBlock().getId(),
+                bt -> createMetadataDto(bt.getTicker().getId(), bt.getTicker().getName(), bt.getSequence(), bt.getStartOffset()));
+
+        Map<Long, BlockDetailResponseDto> dtoMap = createBlockDetailResponseDto(blocks, tagMap, tickerMap);
+
+        BlockDetailResponseDto rootDto = null;
+        for (Block b : blocks) {
+            BlockDetailResponseDto currentDto = dtoMap.get(b.getId());
+            if (b.getId().equals(rootId)) {
+                rootDto = currentDto;
+            } else if (b.getParent() != null) {
+                BlockDetailResponseDto parentDto = dtoMap.get(b.getParent().getId());
+                if (parentDto != null) {
+                    parentDto.getChildren().add(currentDto);
+                }
+            }
+        }
+
+        return rootDto;
+    }
+
+    /** BlockDetailResponseDto 응답 값 생성해주는 메서드 */
+    private Map<Long, BlockDetailResponseDto> createBlockDetailResponseDto(
+            List<Block> blocks,
+            Map<Long, List<BlockDetailResponseDto.MetadataResponse>> tagMap,
+            Map<Long, List<BlockDetailResponseDto.MetadataResponse>> tickerMap) {
+
+        return blocks.stream()
+                .collect(Collectors.toMap(
+                        Block::getId,
+                        b -> BlockDetailResponseDto.builder()
+                                .blockId(b.getId())
+                                .content(b.getContent())
+                                .createdAt(b.getCreatedAt())
+                                .tagNames(tagMap.getOrDefault(b.getId(), new ArrayList<>()))
+                                .tickerNames(tickerMap.getOrDefault(b.getId(), new ArrayList<>()))
+                                .children(new ArrayList<>())
+                                .build()
+                ));
+    }
+
+    /** 공통 맵 생성 메서드 BlockTag, BlockTicker 뭐가 들어올지 모르니 제네릭 활용 */
+    private <T> Map<Long, List<BlockDetailResponseDto.MetadataResponse>> createMetadataMap(
+            List<T> items,
+            Function<T, Long> blockIdExtractor,
+            Function<T, BlockDetailResponseDto.MetadataResponse> mapper
+    ) {
+        return items.stream()
+                .collect(Collectors.groupingBy(
+                        blockIdExtractor,
+                        Collectors.collectingAndThen(
+                                Collectors.mapping(mapper, Collectors.toList()),
+                                list -> {
+                                    list.sort(Comparator.comparing(BlockDetailResponseDto.MetadataResponse::getSequence));
+                                    return list;
+                                }
+                        )
+                ));
+    }
+
+    /** MetadataResponse DTO로 만들어주는 메서드 */
+    private BlockDetailResponseDto.MetadataResponse createMetadataDto(Long id, String name, Integer seq, Integer offset) {
+        return BlockDetailResponseDto.MetadataResponse.builder()
+                .id(id)
+                .name(name)
+                .sequence(seq)
+                .startOffset(offset)
+                .build();
+    }
+
+}

--- a/src/main/java/com/joojoo/api/block/domain/model/entity/Block.java
+++ b/src/main/java/com/joojoo/api/block/domain/model/entity/Block.java
@@ -1,6 +1,8 @@
 package com.joojoo.api.block.domain.model.entity;
 
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -41,6 +43,12 @@ public class Block extends BaseTimeEntity {
 
     @Column(name = "is_saved", nullable = false)
     private Boolean isSaved;
+
+    @OneToMany(mappedBy = "block", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BlockTag> blockTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "block", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BlockTicker> blockTickers = new ArrayList<>();
 
     @Builder
     public Block(User user, Block parent, String content, Integer depth, Integer sequence, Boolean isSaved) {

--- a/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
+++ b/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
@@ -8,4 +8,6 @@ public interface BlockRepository {
     Block save(Block block);
 
     List<Block> saveAll(List<Block> allBlocks);
+
+    List<Block> findAllChildrenByRootId(Long blockId);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepository.java
@@ -1,0 +1,10 @@
+package com.joojoo.api.block.infrastructure.queryDsl;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+
+import java.util.List;
+
+public interface BlockQueryDslRepository {
+    List<Block> findAllChildrenByRootId(Long blockId);
+
+}

--- a/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.joojoo.api.block.infrastructure.queryDsl;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.domain.model.entity.QBlock;
+import com.joojoo.global.exception.handleException.block.BlockNotFoundException;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockQueryDslRepositoryImpl implements BlockQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QBlock block = QBlock.block;
+
+    @Override
+    public List<Block> findAllChildrenByRootId(Long rootId) {
+        List<Long> childIds = fetchChildIds(rootId);
+
+        return queryFactory
+                .selectFrom(block)
+                .where(allBlocksInTree(rootId, childIds))
+                .fetch();
+    }
+
+    /** 부모ID 가 있는 자식 블록 ID만 조회합니다. */
+    private List<Long> fetchChildIds(Long rootId) {
+        return queryFactory
+                .select(block.id)
+                .from(block)
+                .where(block.parent.id.eq(rootId))
+                .fetch();
+    }
+
+    /** 부모 - 자식 - 자손 을 조건으로 만들어주는 메서드 */
+    private BooleanBuilder allBlocksInTree(Long rootId, List<Long> childIds) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.or(block.id.eq(rootId)); // 부모 
+        builder.or(block.parent.id.eq(rootId)); // 자식 
+
+        if (!childIds.isEmpty()) {
+            builder.or(block.parent.id.in(childIds)); // 자손
+        }
+
+        return builder.and(block.isDeleted.isFalse());
+    }
+
+}

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
@@ -2,6 +2,9 @@ package com.joojoo.api.block.infrastructure.rdbms;
 
 import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.repository.BlockRepository;
+import com.joojoo.api.block.infrastructure.queryDsl.BlockQueryDslRepository;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +15,7 @@ import java.util.List;
 public class BlockRepositoryImpl implements BlockRepository {
 
     private final BlockJpaRepository blockJpaRepository;
+    private final BlockQueryDslRepository blockQueryDslRepository;
 
     @Override
     public Block save(Block block) {
@@ -22,4 +26,10 @@ public class BlockRepositoryImpl implements BlockRepository {
     public List<Block> saveAll(List<Block> allBlocks) {
         return blockJpaRepository.saveAll(allBlocks);
     }
+
+    @Override
+    public List<Block> findAllChildrenByRootId(Long blockId) {
+        return blockQueryDslRepository.findAllChildrenByRootId(blockId);
+    }
+
 }

--- a/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
+++ b/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
@@ -3,6 +3,7 @@ package com.joojoo.api.block.presentation.controller;
 import com.joojoo.api.block.application.BlockService;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.global.common.request.auth.CustomUserDetails;
 import com.joojoo.global.common.response.BaseResponse;
 import com.joojoo.global.common.response.ErrorResponse;
@@ -14,10 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Block API", description = "블럭(노트) 관련 API")
 @RestController
@@ -46,6 +44,24 @@ public class BlockController {
             @RequestBody BlockSaveRequestDto requestDto
     ) {
         return BaseResponse.ok(blockService.saveBlockTree(user.getUserId(), requestDto));
+    }
+
+    @Operation(summary = "블럭(노트) 상세 페이지", description = "메인 페이지에서 더보기 버튼 누르면 자식, 자손 블럭까지 응답 합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = BlockResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "없는 블럭입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/detail/{blockId}")
+    public BaseResponse<BlockDetailResponseDto> getBlockDetail(@PathVariable Long blockId) {
+        return BaseResponse.ok(blockService.getBlockDetail(blockId));
     }
 
 }

--- a/src/main/java/com/joojoo/api/block/presentation/dto/response/detail/BlockDetailResponseDto.java
+++ b/src/main/java/com/joojoo/api/block/presentation/dto/response/detail/BlockDetailResponseDto.java
@@ -1,0 +1,37 @@
+package com.joojoo.api.block.presentation.dto.response.detail;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BlockDetailResponseDto {
+    private Long blockId;
+    private String content;
+    private LocalDateTime createdAt;
+    private List<MetadataResponse> tagNames;
+    private List<MetadataResponse> tickerNames;
+    private List<BlockDetailResponseDto> children;
+
+    @Getter
+    @Builder
+    public static class MetadataResponse {
+        private Long id;
+        private String name;
+        private Integer sequence;
+        private Integer startOffset;
+
+        public static MetadataResponse of(Long id, String name, Integer sequence, Integer startOffset) {
+            return MetadataResponse.builder()
+                    .id(id)
+                    .name(name)
+                    .sequence(sequence)
+                    .startOffset(startOffset)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
@@ -1,11 +1,9 @@
-package com.joojoo.api.blockTag.domain.repository;
+package com.joojoo.api.blockTag.infrastructure.queryDsl;
 
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 
 import java.util.List;
 
-public interface BlockTagRepository {
-    List<BlockTag> saveAll(List<BlockTag> blockTags);
-
+public interface BlockTagQueryDslRepository {
     List<BlockTag> findAllBlockTags(List<Long> blockIds);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.joojoo.api.blockTag.infrastructure.queryDsl;
+
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.domain.model.entity.QBlockTag;
+import com.joojoo.api.tag.domain.model.entity.QTag;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockTagQueryDslRepositoryImpl implements BlockTagQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QBlockTag blockTag = QBlockTag.blockTag;
+    private final QTag tag = QTag.tag;
+
+    @Override
+    public List<BlockTag> findAllBlockTags(List<Long> blockIds) {
+        return queryFactory
+                .selectFrom(blockTag)
+                .join(blockTag.tag, tag).fetchJoin()
+                .where(blockTag.block.id.in(blockIds))
+                .fetch();
+    }
+}

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.joojoo.api.blockTag.infrastructure.rdbms;
 
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.blockTag.infrastructure.queryDsl.BlockTagQueryDslRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,10 +13,15 @@ import java.util.List;
 public class BlockTagRepositoryImpl implements BlockTagRepository {
 
     private final BlockTagJpaRepository blockTagJpaRepository;
-
+    private final BlockTagQueryDslRepository blockTagQueryDslRepository;
 
     @Override
     public List<BlockTag> saveAll(List<BlockTag> blockTags) {
         return blockTagJpaRepository.saveAll(blockTags);
+    }
+
+    @Override
+    public List<BlockTag> findAllBlockTags(List<Long> blockIds) {
+        return blockTagQueryDslRepository.findAllBlockTags(blockIds);
     }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepository.java
@@ -1,11 +1,9 @@
-package com.joojoo.api.blockTicker.domain.repository;
+package com.joojoo.api.blockTicker.infrastructure.queryDsl;
 
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 
 import java.util.List;
 
-public interface BlockTickerRepository {
-    List<BlockTicker> saveAll(List<BlockTicker> blockTickers);
-
+public interface BlockTickerQueryDslRepository {
     List<BlockTicker> findAllBlockTickers(List<Long> blockIds);
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.joojoo.api.blockTicker.infrastructure.queryDsl;
+
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.blockTicker.domain.model.entity.QBlockTicker;
+import com.joojoo.api.ticker.domain.model.entity.QTicker;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockTickerQueryDslRepositoryImpl implements BlockTickerQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QBlockTicker blockTicker = QBlockTicker.blockTicker;
+    private final QTicker ticker = QTicker.ticker;
+
+    @Override
+    public List<BlockTicker> findAllBlockTickers(List<Long> blockIds) {
+        return queryFactory
+                .selectFrom(blockTicker)
+                .join(blockTicker.ticker, ticker).fetchJoin()
+                .where(blockTicker.block.id.in(blockIds))
+                .fetch();
+    }
+}

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.joojoo.api.blockTicker.infrastructure.rdbms;
 
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
+import com.joojoo.api.blockTicker.infrastructure.queryDsl.BlockTickerQueryDslRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,9 +13,15 @@ import java.util.List;
 public class BlockTickerRepositoryImpl implements BlockTickerRepository {
 
     private final BlockTickerJpaRepository blockTickerJpaRepository;
+    private final BlockTickerQueryDslRepository blockTickerQueryDslRepository;
 
     @Override
     public List<BlockTicker> saveAll(List<BlockTicker> blockTickers) {
         return blockTickerJpaRepository.saveAll(blockTickers);
+    }
+
+    @Override
+    public List<BlockTicker> findAllBlockTickers(List<Long> blockIds) {
+        return blockTickerQueryDslRepository.findAllBlockTickers(blockIds);
     }
 }

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     //---------------------------- 블럭 (Block) ----------------------------
     INVALID_ROOT_BLOCK_COUNT(400, "INVALID_ROOT_BLOCK_COUNT", "최상위 블록(부모)은 반드시 1개여야 합니다."),
     MAX_BLOCK_DEPTH_EXCEEDED(400, "MAX_BLOCK_DEPTH_EXCEEDED", "블록 계층은 최대 2단계(Depth 2)까지만 허용됩니다."),
+    BLOCK_NOT_FOUND(404, "BLOCK_NOT_FOUND", "해당 블록을 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/com/joojoo/global/exception/handleException/block/BlockNotFoundException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/block/BlockNotFoundException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.block;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class BlockNotFoundException extends ServiceException  {
+    private static final ErrorCode errorCode = ErrorCode.BLOCK_NOT_FOUND;
+
+    public BlockNotFoundException() {
+        super(errorCode);
+    }
+
+    public BlockNotFoundException(Exception exception) {
+        super(errorCode, exception);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Refactor] 블록 상세 조회 로직 최적화 및 2뎁스 트리 구조 조립 구현

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

블록 상세 조회 시 발생하는 데이터 조립 복잡도를 해결하고, 부모-자식-자손(2뎁스)으로 이어지는 트리 구조 데이터를 효율적으로 응답하도록 기능 개발 및 리팩토링을 진행했습니다.

---

## 작업 내용

- **서비스 레이어 책임 분리 및 가공 로직 최적화**
  - 복잡한 트리 조립 및 데이터 매핑 로직을 `BlockDtoAssembler` 클래스로 분리하여 서비스 레이어의 가독성 향상
  - `Stream API`와 `groupingBy`를 활용하여 블록별 태그/티커 메타데이터를 일괄 매핑함으로써 N+1 문제 방지
  - `Function` 인터페이스를 활용한 제네릭 메서드를 구현하여 메타데이터 그룹화 로직의 중복 제거

- **QueryDSL 기반의 효율적인 2뎁스 조회 구현**
  - 뎁스 제한(2Depth) 조건에 맞춰, 자식 블록(Depth 1)의 ID를 기반으로 자손(Depth 2)까지 단 2번의 쿼리로 모든 트리 데이터를 로드하도록 쿼리 개선
  - `BooleanBuilder`를 사용하여 삭제된 블록 필터링 및 동적 쿼리 조건 처리

- **상세 페이지 및 아코디언 UI 대응 DTO 설계**
  - 블록 엔티티의 생성 날짜(`createdAt`) 필드를 DTO에 추가하여 상세 정보 제공
  - 메인 페이지의 '더보기' 기능을 지원하기 위해 `childCount` 필드 설계 및 계층형 `children` 리스트 구조 확립

- **도메인 모델 양방향 연관관계 설정 및 생명주기 관리 최적화**
  - `Block` 엔티티와 `BlockTag`, `BlockTicker` 간의 양방향 연관관계를 설정하여 객체 그래프 탐색 편의성 제공
  - `cascade = CascadeType.ALL` 및 `orphanRemoval = true` 설정을 통해 블록 삭제 시 관련 메타데이터(태그, 티커)가 함께 관리되도록 데이터 무결성 보장
 
---

## 관련 이슈
