### PR TITLE
Feat/block service clean up

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -52,10 +52,8 @@ public class BlockServiceImpl implements BlockService {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         List<Block> allBlocks = createAndSaveBlocks(user, requestDto.getBlocks());
-        BlockResponse blockResponse = reconstructBlockTree(allBlocks);
-
         metadataService.processMetadata(allBlocks);
-        return blockResponse;
+        return blockDtoAssembler.assembleReconstructBlockTree(allBlocks);
     }
 
     @Override
@@ -98,30 +96,6 @@ public class BlockServiceImpl implements BlockService {
         List<Block> allBlocks = new ArrayList<>();
         blocksRecursive(user, null, dtos, allBlocks);
         return blockRepository.saveAll(allBlocks); // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중
-    }
-
-    /** List에서 다시 트리 형식으로 변환 */
-    private BlockResponse reconstructBlockTree(List<Block> blocks) {
-        // ID를 키로 하는 DTO Map 생성
-        Map<Long, BlockResponseDto> dtoMap = blocks.stream()
-                .map(block -> BlockResponseDto.of(block, new ArrayList<>()))
-                .collect(Collectors.toMap(BlockResponseDto::getBlockId, dto -> dto));
-
-        // 부모-자식 연결 및 루트 블록 추출
-        List<BlockResponseDto> rootBlocks = new ArrayList<>();
-        for (Block block : blocks) {
-            BlockResponseDto currentDto = dtoMap.get(block.getId());
-
-            if (block.getParent() == null) {
-                rootBlocks.add(currentDto);
-            } else {
-                BlockResponseDto parentDto = dtoMap.get(block.getParent().getId());
-                if (parentDto != null) {
-                    parentDto.getChildren().add(currentDto);
-                }
-            }
-        }
-        return BlockResponse.of(rootBlocks);
     }
 
     /** RequestDto를 순회하며 JPA 엔티티(Block)를 생성하고, allBlocks에 수집하는 메서드 */

--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -74,7 +74,7 @@ public class BlockServiceImpl implements BlockService {
     @Override
     @Transactional(readOnly = true)
     public BlockMainViewResponse getBlockMainView(Long userId, LocalDate lastDate) {
-        LocalDate targetDate = validateAndGetTargetDate(lastDate);
+        LocalDate targetDate = blockTreeValidator.validateAndGetTargetDate(lastDate);
 
         List<Block> rootBlocks = blockRepository.findBlocksByLatestDates(userId, targetDate, 2);
         if (rootBlocks.isEmpty()) {
@@ -91,14 +91,6 @@ public class BlockServiceImpl implements BlockService {
         LocalDate nextDate = blockRepository.findNextAvailableDate(userId, oldestDateInResult);
 
         return BlockMainViewResponse.of(allDtos, nextDate);
-    }
-
-    /** 날짜가 없거나, 미래 날짜이면 오늘 날짜로 변경 */
-    private LocalDate validateAndGetTargetDate(LocalDate lastDate) {
-        if (lastDate == null || lastDate.isAfter(LocalDate.now())) {
-            return LocalDate.now();
-        }
-        return lastDate;
     }
 
     /** 리스트에 블럭을 담아 한번에 저장하는 메서드 */

--- a/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssembler.java
+++ b/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssembler.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.block.application.detail;
 
 import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
@@ -15,4 +16,6 @@ public interface BlockDtoAssembler {
     // 메인 페이지용
     List<BlockDetailResponseDto> assembleMainList(List<Block> blocks, List<BlockTag> tags, List<BlockTicker> tickers, Map<Long, Long> childCounts);
 
+    // 리스트형식에서 응답 형식인 트리구조로 변환
+    BlockResponse assembleReconstructBlockTree(List<Block> allBlocks);
 }

--- a/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssemblerImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssemblerImpl.java
@@ -1,6 +1,8 @@
 package com.joojoo.api.block.application.detail;
 
 import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponseDto;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
@@ -28,13 +30,15 @@ public class BlockDtoAssemblerImpl implements BlockDtoAssembler {
         Map<Long, BlockDetailResponseDto> dtoMap = blocks.stream()
                 .collect(Collectors.toMap(
                         Block::getId,
-                        b -> BlockDetailResponseDto.fromSummary(
-                                b, tagMap.getOrDefault(b.getId(),
-                                new ArrayList<>()), tickerMap.getOrDefault(b.getId(),
-                                new ArrayList<>()),
-                                childCountMap.getOrDefault(b.getId(), 0L)
+                        block -> BlockDetailResponseDto.fromSummary
+                                (
+                                        block,
+                                        tagMap.getOrDefault(block.getId(), new ArrayList<>()),
+                                        tickerMap.getOrDefault(block.getId(), new ArrayList<>()),
+                                        childCountMap.getOrDefault(block.getId(), 0L)
+                                )
                         )
-                ));
+                );
 
         return buildTreeAndGetRoot(rootId, blocks, dtoMap);
     }
@@ -45,13 +49,49 @@ public class BlockDtoAssemblerImpl implements BlockDtoAssembler {
         Map<Long, List<BlockDetailResponseDto.MetadataResponse>> tickerMap = createTickerMap(tickers);
 
         return blocks.stream()
-                .map(b -> BlockDetailResponseDto.fromSummary(
-                        b,
-                        tagMap.getOrDefault(b.getId(), new ArrayList<>()),
-                        tickerMap.getOrDefault(b.getId(), new ArrayList<>()),
-                        childCounts.getOrDefault(b.getId(), 0L)
+                .map(block -> BlockDetailResponseDto.fromSummary(
+                        block,
+                        tagMap.getOrDefault(block.getId(), new ArrayList<>()),
+                        tickerMap.getOrDefault(block.getId(), new ArrayList<>()),
+                        childCounts.getOrDefault(block.getId(), 0L)
                 ))
                 .toList();
+    }
+
+    @Override
+    public BlockResponse assembleReconstructBlockTree(List<Block> allBlocks) {
+        Map<Long, BlockResponseDto> dtoMap = getBlockResponseDtoMap(allBlocks);
+        connectNodes(allBlocks, dtoMap);
+        return BlockResponse.of(getRootBlocks(allBlocks, dtoMap));
+    }
+
+    /** Root 블럭만 추출해 리스트로 변환 */
+    private static List<BlockResponseDto> getRootBlocks(List<Block> allBlocks, Map<Long, BlockResponseDto> dtoMap) {
+        return allBlocks.stream()
+                .filter(b -> b.getParent() == null)
+                .map(b -> dtoMap.get(b.getId()))
+                .toList();
+    }
+
+    /** BlockResponseDto 전용 맵 생성 */
+    private static Map<Long, BlockResponseDto> getBlockResponseDtoMap(List<Block> allBlocks) {
+        return allBlocks.stream()
+                .map(block -> BlockResponseDto.of(block, new ArrayList<>()))
+                .collect(Collectors.toMap(BlockResponseDto::getBlockId, dto -> dto));
+    }
+
+    /** 부모-자식 관계 연결 담당하는 전용 메서드 */
+    private void connectNodes(List<Block> allBlocks, Map<Long, BlockResponseDto> dtoMap) {
+        for (Block block : allBlocks) {
+            if (block.getParent() != null) { // 부모 블럭이 아니면
+                // 부모 블럭을 찾는다.
+                BlockResponseDto parentDto = dtoMap.get(block.getParent().getId());
+                if (parentDto != null) { // 부모 블럭이 있다면
+                    // 부모블럭에 현재 자식 블럭을 추가한다.
+                    parentDto.getChildren().add(dtoMap.get(block.getId()));
+                }
+            }
+        }
     }
 
     /** Tag 전용 맵 생성 */

--- a/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidator.java
+++ b/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidator.java
@@ -2,6 +2,12 @@ package com.joojoo.api.block.application.validate.blockerTree;
 
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 
+import java.time.LocalDate;
+
 public interface BlockTreeValidator {
+    /** 트리 구조 검증 */
     void validateStructure(BlockSaveRequestDto requestDto);
+
+    /** 날짜가 없거나, 미래 날짜이면 오늘 날짜로 변경 */
+    LocalDate validateAndGetTargetDate(LocalDate lastDate);
 }

--- a/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidatorImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidatorImpl.java
@@ -6,6 +6,8 @@ import com.joojoo.global.exception.enums.ErrorCode;
 import com.joojoo.global.exception.handleException.block.InvalidBlockStructureException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
 public class BlockTreeValidatorImpl implements BlockTreeValidator {
 
@@ -18,6 +20,14 @@ public class BlockTreeValidatorImpl implements BlockTreeValidator {
         }
 
         validateDepth(requestDto.getBlocks().get(0), 0);
+    }
+
+    @Override /** 날짜가 없거나, 미래 날짜이면 오늘 날짜로 변경 */
+    public LocalDate validateAndGetTargetDate(LocalDate lastDate) {
+        if (lastDate == null || lastDate.isAfter(LocalDate.now())) {
+            return LocalDate.now();
+        }
+        return lastDate;
     }
 
     private void validateDepth(BlockRequestDto block, int currentDepth) {


### PR DESCRIPTION
## 📌 PR 제목

- [Refactor] Block 서비스 책임 분리 및 구조 개선

---

## PR Checklist

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선) - [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

- [ ] 버그수정 (Bugfix)
- [ ] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

Block Application Service의 책임이 과도하게 집중되어 있던 구조를 개선하기 위해  
**검증 로직과 DTO 조립 로직을 각각 전용 컴포넌트로 분리** 했습니다.

이를 통해 Application Service는 **유스케이스 흐름 제어 역할에 집중** 하도록 리팩토링했습니다.

---

## 작업 내용

- **BlockTreeValidator**
  - 블록 트리 구조 검증 로직을 Application Service에서 분리
  - depth, sequence, 트리 구조, 날짜 유효성 검증 책임을 전담하도록 변경
  - 유효성 검증 로직의 재사용성과 테스트 용이성 개선

- **BlockDtoAssembler**
  - Block, Tag, Ticker를 조합하여 응답 DTO를 생성하는 로직을 분리
  - Application Service에서 DTO 생성 책임 제거
  - 트리 재구성 로직(`assembleReconstructBlockTree`, `assembleTree`, `assembleMainList`)을 한 곳에서 관리

- **BlockServiceImpl**
  - 유스케이스 흐름 제어 중심으로 역할 축소
  - 검증 → 저장 → 메타데이터 처리 → DTO 조립의 흐름만 담당하도록 정리
  - 가독성 및 유지보수성 향상

---

## 관련 이슈
