### PR TITLE
refactor: 티커, 태그 중간 테이블에 `userId` 필드 추가 및 그에 맞게 서비스로직 수정

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -54,7 +54,7 @@ public class BlockServiceImpl implements BlockService {
         List<Block> allBlocks = createAndSaveBlocks(user, requestDto.getBlocks());
         BlockResponse blockResponse = reconstructBlockTree(allBlocks);
 
-        metadataService.processMetadata(allBlocks);
+        metadataService.processMetadata(allBlocks, user.getId());
         return blockResponse;
     }
 

--- a/src/main/java/com/joojoo/api/block/application/metadata/MetadataService.java
+++ b/src/main/java/com/joojoo/api/block/application/metadata/MetadataService.java
@@ -2,10 +2,6 @@ package com.joojoo.api.block.application.metadata;
 
 import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.presentation.dto.request.metadata.MatchedMetadataDto;
-import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
-import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
-import com.joojoo.api.tag.domain.model.entity.Tag;
-import com.joojoo.api.ticker.domain.model.entity.Ticker;
 
 import java.util.List;
 import java.util.Map;
@@ -14,7 +10,5 @@ import java.util.Set;
 public interface MetadataService {
     Map<Block, List<MatchedMetadataDto>> scanBlocks(List<Block> allBlocks, Set<String> tickerNames, Set<String> tagNames);
 
-    void mapToEntities(Block block, List<MatchedMetadataDto> matches, Map<String, Ticker> tickerMap, Map<String, Tag> tagMap, List<BlockTicker> blockTickers, List<BlockTag> blockTags);
-
-    void processMetadata(List<Block> allBlocks);
+    void processMetadata(List<Block> allBlocks, Long userId);
 }

--- a/src/main/java/com/joojoo/api/block/application/metadata/MetadataServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/metadata/MetadataServiceImpl.java
@@ -31,7 +31,7 @@ public class MetadataServiceImpl implements MetadataService {
     private final BlockTagRepository blockTagRepository;
 
     @Override
-    public void processMetadata(List<Block> blocks) {
+    public void processMetadata(List<Block> blocks, Long userId) {
         // 정규식 메타데이버 검사
         Set<String> tickerNames = new HashSet<>();
         Set<String> tagNames = new HashSet<>();
@@ -47,7 +47,7 @@ public class MetadataServiceImpl implements MetadataService {
 
         for (Block block : blocks) {
             List<MatchedMetadataDto> matches = analysisMap.getOrDefault(block, Collections.emptyList());
-            mapToEntities(block, matches, tickerMap, tagMap, blockTickers, blockTags);
+            mapToEntities(block, matches, tickerMap, tagMap, blockTickers, blockTags, userId);
         }
 
         // TODO : JDBC Batch Insert 고려, 지금 중간 테이블이 10개면 10개의 Insert 쿼리 작동 중
@@ -84,8 +84,7 @@ public class MetadataServiceImpl implements MetadataService {
     }
 
     /** 추출된 맵을 바탕으로 BlockTicker, BlockTag 중간 테이블 엔티티 생성 */
-    @Override
-    public void mapToEntities(Block block, List<MatchedMetadataDto> matches, Map<String, Ticker> tickerMap, Map<String, Tag> tagMap, List<BlockTicker> bTickers, List<BlockTag> bTags) {
+    public void mapToEntities(Block block, List<MatchedMetadataDto> matches, Map<String, Ticker> tickerMap, Map<String, Tag> tagMap, List<BlockTicker> bTickers, List<BlockTag> bTags, Long userId) {
         if (block.getContent() == null) return;
 
         AtomicInteger tSeq = new AtomicInteger();
@@ -94,10 +93,10 @@ public class MetadataServiceImpl implements MetadataService {
         for (MatchedMetadataDto match : matches) {
             if (match.isTicker()) {
                 Optional.ofNullable(tickerMap.get(match.name()))
-                        .ifPresent(t -> bTickers.add(BlockTicker.create(block, t, match.start(), tSeq.getAndIncrement())));
+                        .ifPresent(t -> bTickers.add(BlockTicker.create(block, t, userId, match.start(), tSeq.getAndIncrement())));
             } else {
                 Optional.ofNullable(tagMap.get(match.name()))
-                        .ifPresent(tag -> bTags.add(BlockTag.create(block, tag, match.start(), tagSeq.getAndIncrement())));
+                        .ifPresent(tag -> bTags.add(BlockTag.create(block, tag, userId, match.start(), tagSeq.getAndIncrement())));
             }
         }
     }

--- a/src/main/java/com/joojoo/api/blockTag/domain/model/entity/BlockTag.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/model/entity/BlockTag.java
@@ -9,9 +9,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -35,24 +32,29 @@ public class BlockTag extends BaseCreateEntity {
     @JoinColumn(name = "trade_log_id")
     private TradeLog tradeLog;
 
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
     private Integer sequence;
 
     @Column(name = "start_offset")
     private Integer startOffset;
 
     @Builder
-    public BlockTag(Tag tag, Block block, TradeLog tradeLog, Integer sequence, Integer startOffset) {
+    public BlockTag(Tag tag, Block block, TradeLog tradeLog, Long userId, Integer sequence, Integer startOffset) {
         this.tag = tag;
         this.block = block;
         this.tradeLog = tradeLog;
+        this.userId = userId;
         this.sequence = sequence;
         this.startOffset = startOffset;
     }
 
-    public static BlockTag create(Block block, Tag tag, int start, int tagSeq) {
+    public static BlockTag create(Block block, Tag tag, Long userId, int start, int tagSeq) {
         return BlockTag.builder()
                 .block(block)
                 .tag(tag)
+                .userId(userId)
                 .sequence(tagSeq)
                 .startOffset(start)
                 .build();

--- a/src/main/java/com/joojoo/api/blockTicker/domain/model/entity/BlockTicker.java
+++ b/src/main/java/com/joojoo/api/blockTicker/domain/model/entity/BlockTicker.java
@@ -32,24 +32,29 @@ public class BlockTicker extends BaseCreateEntity {
     @JoinColumn(name = "trade_log_id")
     private TradeLog tradeLog;
 
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
     private Integer sequence;
 
     @Column(name = "start_offset")
     private Integer startOffset;
 
     @Builder
-    public BlockTicker(Block block, Ticker ticker, TradeLog tradeLog, Integer sequence, Integer startOffset) {
+    public BlockTicker(Block block, Ticker ticker, TradeLog tradeLog, Long userId, Integer sequence, Integer startOffset) {
         this.block = block;
         this.ticker = ticker;
         this.tradeLog = tradeLog;
+        this.userId = userId;
         this.sequence = sequence;
         this.startOffset = startOffset;
     }
 
-    public static BlockTicker create(Block block, Ticker ticker, int start, int tSeq) {
+    public static BlockTicker create(Block block, Ticker ticker, Long userId, int start, int tSeq) {
         return BlockTicker.builder()
                 .block(block)
                 .ticker(ticker)
+                .userId(userId)
                 .sequence(tSeq)
                 .startOffset(start)
                 .build();


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 최근 사용 태그 및 티커 조회 성능 최적화를 위한 userId 컬럼 추가

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [ ] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

`BlockTag`, `BlockTicker` 엔티티에 userId 컬럼을 추가하여 조회 성능을 개선하고 쿼리 복잡도를 낮추었습니다.

---

## 작업 내용

- 기존 최근 사용 태그 10개를 가져오기 위해 `BlockTag` -> `Block` -> `User` 순으로 조인이 필요했으나, 데이터가 많은 `Block` 테이블 조인 시 성능 저하 우려가 있음
  - `BlockTag`와 `BlockTicker`에 userId를 직접 추가하여 Block 테이블 조인 없이 인덱스만으로 데이터 추출할 수 있게 수정 
  - `BlockTag`와 `BlockTicker`에 user_id를 직접 들고 있게 함으로써, 텍스트 데이터가 많아 무거운 `Block` 테이블을 거치지 않고도 원하는 데이터를 즉시 필터링할 수 있도록 개선했습니다.

---

## 관련 이슈
