### PR TITLE
feat: 최근 사용했던 태그 정보 10개 조회 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/blockTag/application/BlockTagService.java
+++ b/src/main/java/com/joojoo/api/blockTag/application/BlockTagService.java
@@ -1,0 +1,7 @@
+package com.joojoo.api.blockTag.application;
+
+import com.joojoo.api.blockTag.presentation.dto.response.RecentTagsResponse;
+
+public interface BlockTagService {
+    RecentTagsResponse getRecentTags(Long userId);
+}

--- a/src/main/java/com/joojoo/api/blockTag/application/BlockTagServiceImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/application/BlockTagServiceImpl.java
@@ -1,0 +1,21 @@
+package com.joojoo.api.blockTag.application;
+
+import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.blockTag.presentation.dto.response.RecentTagsResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BlockTagServiceImpl implements BlockTagService {
+
+    private final BlockTagRepository blockTagRepository;
+
+    @Override
+    public RecentTagsResponse getRecentTags(Long userId) {
+        return RecentTagsResponse.of(blockTagRepository.findRecentTags(userId));
+    }
+
+}

--- a/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.blockTag.domain.repository;
 
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.presentation.dto.response.RecentTagsResponse;
 
 import java.util.List;
 
@@ -8,4 +9,6 @@ public interface BlockTagRepository {
     List<BlockTag> saveAll(List<BlockTag> blockTags);
 
     List<BlockTag> findAllBlockTags(List<Long> blockIds);
+
+    List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
@@ -1,9 +1,12 @@
 package com.joojoo.api.blockTag.infrastructure.queryDsl;
 
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.presentation.dto.response.RecentTagsResponse;
 
 import java.util.List;
 
 public interface BlockTagQueryDslRepository {
     List<BlockTag> findAllBlockTags(List<Long> blockIds);
+
+    List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.joojoo.api.blockTag.infrastructure.queryDsl;
 
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTag.domain.model.entity.QBlockTag;
+import com.joojoo.api.blockTag.presentation.dto.response.RecentTagsResponse;
 import com.joojoo.api.tag.domain.model.entity.QTag;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -23,6 +25,22 @@ public class BlockTagQueryDslRepositoryImpl implements BlockTagQueryDslRepositor
                 .selectFrom(blockTag)
                 .join(blockTag.tag, tag).fetchJoin()
                 .where(blockTag.block.id.in(blockIds))
+                .fetch();
+    }
+
+    @Override
+    public List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId) {
+        return queryFactory
+                .select(Projections.constructor(RecentTagsResponse.RecentTagsDto.class,
+                        tag.id,
+                        tag.name
+                ))
+                .from(blockTag)
+                .join(blockTag.tag, tag)
+                .where(blockTag.userId.eq(userId))
+                .groupBy(tag.id)
+                .orderBy(blockTag.id.max().desc())
+                .limit(10)
                 .fetch();
     }
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.joojoo.api.blockTag.infrastructure.rdbms;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
 import com.joojoo.api.blockTag.infrastructure.queryDsl.BlockTagQueryDslRepository;
+import com.joojoo.api.blockTag.presentation.dto.response.RecentTagsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -23,5 +24,10 @@ public class BlockTagRepositoryImpl implements BlockTagRepository {
     @Override
     public List<BlockTag> findAllBlockTags(List<Long> blockIds) {
         return blockTagQueryDslRepository.findAllBlockTags(blockIds);
+    }
+
+    @Override
+    public List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId) {
+        return blockTagQueryDslRepository.findRecentTags(userId);
     }
 }

--- a/src/main/java/com/joojoo/api/blockTag/presentation/controller/BlockTagController.java
+++ b/src/main/java/com/joojoo/api/blockTag/presentation/controller/BlockTagController.java
@@ -1,0 +1,41 @@
+package com.joojoo.api.blockTag.presentation.controller;
+
+import com.joojoo.api.blockTag.application.BlockTagService;
+import com.joojoo.api.blockTag.presentation.dto.response.RecentTagsResponse;
+import com.joojoo.global.common.request.auth.CustomUserDetails;
+import com.joojoo.global.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Tag API", description = "Tag 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tags")
+public class BlockTagController {
+
+    private final BlockTagService blockTagService;
+
+    @Operation(summary = "Tag 최근 사용 기록", description = "Tag 작성할때 최근 10개 기록 리스트 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = RecentTagsResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/recent")
+    public BaseResponse<RecentTagsResponse> getRecentTags(
+            @AuthenticationPrincipal CustomUserDetails user
+    ){
+        return BaseResponse.ok(blockTagService.getRecentTags(user.getUserId()));
+    }
+
+}

--- a/src/main/java/com/joojoo/api/blockTag/presentation/dto/response/RecentTagsResponse.java
+++ b/src/main/java/com/joojoo/api/blockTag/presentation/dto/response/RecentTagsResponse.java
@@ -1,0 +1,24 @@
+package com.joojoo.api.blockTag.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class RecentTagsResponse {
+    private List<RecentTagsDto> tags;
+
+    public static RecentTagsResponse of(List<RecentTagsDto> tags) {
+        return new RecentTagsResponse(tags);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class RecentTagsDto {
+        private Long tagId;
+        private String tagName;
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 기능 제목
- [Fix] 버그 제목

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [ ] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

노트 작성시에 최근 사용한 태그 10개의 기록 조회 API를 구현했습니다.

---

## 작업 내용

- `findRecentTags` QueryDsl로 쿼리를 작성 
  - 최근 10개의 태그 사용 기록을 가져오는데 증복이 되기 때문에 태그 id를 그룹화하여 증복을 제거함

---

## 관련 이슈

