### PR TITLE
feat: 블럭 삭제 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockService.java
@@ -1,5 +1,6 @@
 package com.joojoo.api.block.application;
 
+import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
@@ -13,4 +14,6 @@ public interface BlockService {
     BlockDetailResponseDto getBlockDetail(Long blockId);
 
     BlockMainViewResponse getBlockMainView(Long userId, LocalDate lastDate);
+
+    void deleteBlock(Long userId, Long blockId, DeleteMode mode);
 }

--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -4,6 +4,7 @@ import com.joojoo.api.block.application.detail.BlockDtoAssembler;
 import com.joojoo.api.block.application.metadata.MetadataService;
 import com.joojoo.api.block.application.validate.blockerTree.BlockTreeValidator;
 import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
@@ -17,6 +18,7 @@ import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
 import com.joojoo.global.exception.handleException.block.BlockNotFoundException;
+import com.joojoo.global.exception.handleException.block.BlockOwnerMismatchException;
 import com.joojoo.global.exception.handleException.users.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -87,6 +89,65 @@ public class BlockServiceImpl implements BlockService {
         LocalDate nextDate = blockRepository.findNextAvailableDate(userId, oldestDateInResult);
 
         return BlockMainViewResponse.of(allDtos, nextDate);
+    }
+
+    @Override
+    @Transactional
+    public void deleteBlock(Long userId, Long blockId, DeleteMode mode) {
+        Block targetBlock = blockRepository.findByIdWithChildren(blockId)
+                .orElseThrow(BlockNotFoundException::new);
+
+        blockTreeValidator.validateOwner(targetBlock, userId);
+
+        if (mode == DeleteMode.ALL) {
+            handleRecursiveDelete(targetBlock);
+        } else {
+            handleSingleDeleteWithPromotion(targetBlock);
+        }
+    }
+
+    /** 자식들 시퀀스 앞으로 댕기고 삭제 */
+    private void handleRecursiveDelete(Block targetBlock) {
+        // 형제들 시퀀스 앞으로 한 칸씩 당기기
+        shiftSiblings(targetBlock, -1);
+
+        // 삭제할 모든 ID 수집 후 일괄 삭제
+        List<Long> idsToDelete = new ArrayList<>();
+        targetBlock.collectAllIds(idsToDelete);
+        blockRepository.deleteAllByIdInBatch(idsToDelete);
+    }
+
+    /** 블럭 정보를 수정한 후 연관관계 삭제 */
+    private void handleSingleDeleteWithPromotion(Block targetBlock) {
+        Block parentBlock = targetBlock.getParent();
+        List<Block> children = new ArrayList<>(targetBlock.getChildren());
+        blockTreeValidator.validatePromotionLimit(targetBlock, parentBlock);
+
+        // 시퀀스 공간 확보
+        int offset = children.size() - 1;
+        shiftSiblings(targetBlock, offset);
+
+        // 수정된 부모Id 일괄 수정, 그런데 영속성 컨텍스트의 객체들은 여전히 이전 부모를 가리킴
+        blockRepository.updateChildrenParent(targetBlock, parentBlock);
+
+        // 자식 및 모든 자손의 뎁스/시퀀스 조정, 벌크 연산은 메모리 정보를 수정되지 않아 Dirty Checking 해줘야 함
+        int startSeq = targetBlock.getSequence();
+        for (int i = 0; i < children.size(); i++) {
+            children.get(i).promote(parentBlock, startSeq + i);
+        }
+
+        targetBlock.disconnectChildren();
+        blockRepository.delete(targetBlock);
+    }
+
+    /** 시퀀스 조정 메서드 */
+    private void shiftSiblings(Block targetBlock, int offset) {
+        if (offset == 0) return;
+        if (targetBlock.getParent() != null) {
+            blockRepository.updateSequenceWithParent(targetBlock.getUser(), targetBlock.getParent(), targetBlock.getSequence(), offset);
+        } else {
+            blockRepository.updateSequenceRoot(targetBlock.getUser(), targetBlock.getSequence(), offset);
+        }
     }
 
     /** 리스트에 블럭을 담아 한번에 저장하는 메서드 */

--- a/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidator.java
+++ b/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidator.java
@@ -1,5 +1,6 @@
 package com.joojoo.api.block.application.validate.blockerTree;
 
+import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 
 import java.time.LocalDate;
@@ -10,4 +11,10 @@ public interface BlockTreeValidator {
 
     /** 날짜가 없거나, 미래 날짜이면 오늘 날짜로 변경 */
     LocalDate validateAndGetTargetDate(LocalDate lastDate);
+
+    /** 자식들이 부모 레벨로 올라갔을 때 3개 제한을 넘지 않는지 검증 */
+    void validatePromotionLimit(Block targetBlock, Block parentBlock);
+
+    /** 현재 블럭의 작성자 여부 검증 */
+    void validateOwner(Block targetBlock, Long userId);
 }

--- a/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidatorImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidatorImpl.java
@@ -1,17 +1,25 @@
 package com.joojoo.api.block.application.validate.blockerTree;
 
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.global.exception.enums.ErrorCode;
+import com.joojoo.global.exception.handleException.block.BlockOwnerMismatchException;
+import com.joojoo.global.exception.handleException.block.BlockPromotionLimitExceededException;
 import com.joojoo.global.exception.handleException.block.InvalidBlockStructureException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 
 @Service
+@RequiredArgsConstructor
 public class BlockTreeValidatorImpl implements BlockTreeValidator {
 
+    private final BlockRepository blockRepository;
     public static final int MAX_DEPTH = 2;
+
 
     @Override
     public void validateStructure(BlockSaveRequestDto requestDto) {
@@ -28,6 +36,29 @@ public class BlockTreeValidatorImpl implements BlockTreeValidator {
             return LocalDate.now();
         }
         return lastDate;
+    }
+
+    @Override
+    public void validatePromotionLimit(Block targetBlock, Block parentBlock) {
+        if (targetBlock.getDepth() == 0) {
+            return;
+        }
+
+        if (parentBlock != null) {
+            long currentSiblingCount = parentBlock.getChildren().size(); // 현재 뎁스에 형제들 수
+            long childrenToPromoteCount = targetBlock.getChildren().size(); // 승격될 자식들 수
+
+            if ((currentSiblingCount - 1) + childrenToPromoteCount > 3) {
+                throw new BlockPromotionLimitExceededException();
+            }
+        }
+    }
+
+    @Override
+    public void validateOwner(Block targetBlock, Long userId) {
+        if (!targetBlock.getUser().getId().equals(userId)) {
+            throw new BlockOwnerMismatchException();
+        }
     }
 
     private void validateDepth(BlockRequestDto block, int currentDepth) {

--- a/src/main/java/com/joojoo/api/block/domain/model/entity/Block.java
+++ b/src/main/java/com/joojoo/api/block/domain/model/entity/Block.java
@@ -69,4 +69,33 @@ public class Block extends BaseTimeEntity {
                 .isSaved(dto.getIsSaved())
                 .build();
     }
+
+
+    public void promote(Block newParent, int newSequence) {
+        this.parent = newParent;
+        this.sequence = newSequence;
+
+        int targetDepth = (newParent == null) ? 0 : newParent.getDepth() + 1;
+        this.updateDepthRecursive(targetDepth);
+    }
+
+    private void updateDepthRecursive(int newDepth) {
+        this.depth = newDepth;
+        for (Block child : children) {
+            child.updateDepthRecursive(newDepth + 1);
+        }
+    }
+
+    /** 자신을 포함한 모든 하위 자손 ID 수집 (재귀) */
+    public void collectAllIds(List<Long> ids) {
+        ids.add(this.id);
+        for (Block child : children) {
+            child.collectAllIds(ids);
+        }
+    }
+
+    public void disconnectChildren() {
+        this.children.clear();
+    }
+
 }

--- a/src/main/java/com/joojoo/api/block/domain/model/enums/DeleteMode.java
+++ b/src/main/java/com/joojoo/api/block/domain/model/enums/DeleteMode.java
@@ -1,0 +1,14 @@
+package com.joojoo.api.block.domain.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DeleteMode {
+    SINGLE("자신만 삭제"),
+    ALL("전체 삭제")
+    ;
+
+    private final String text;
+}

--- a/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
+++ b/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
@@ -33,13 +33,10 @@ public interface BlockRepository {
 
     void updateChildrenParent(Block targetBlock, Block parentBlock);
 
-    long countByParentIsNullAndUser(User user);
-
     void updateSequenceWithParent(User user, Block parent, int seq, int offset);
 
     void updateSequenceRoot(User user, int seq, int offset);
 
     Optional<Block> findByIdWithChildren(Long blockId);
 
-    void decreaseDepthByIds(User user, List<Long> allDescendantIds);
 }

--- a/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
+++ b/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
@@ -1,10 +1,12 @@
 package com.joojoo.api.block.domain.repository;
 
 import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.user.domain.model.entity.User;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface BlockRepository {
     Block save(Block block);
@@ -22,4 +24,22 @@ public interface BlockRepository {
     LocalDate findNextAvailableDate(Long userId, LocalDate oldestDateInResult);
 
     List<Block> getBlocksByTagId(Long userId, Long tagId, Long lastBlockId, int limit);
+
+    Optional<Block> findById(Long blockId);
+
+    void delete(Block targetBlock);
+
+    void deleteAllByIdInBatch(List<Long> idsToDelete);
+
+    void updateChildrenParent(Block targetBlock, Block parentBlock);
+
+    long countByParentIsNullAndUser(User user);
+
+    void updateSequenceWithParent(User user, Block parent, int seq, int offset);
+
+    void updateSequenceRoot(User user, int seq, int offset);
+
+    Optional<Block> findByIdWithChildren(Long blockId);
+
+    void decreaseDepthByIds(User user, List<Long> allDescendantIds);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockJpaRepository.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockJpaRepository.java
@@ -1,9 +1,45 @@
 package com.joojoo.api.block.infrastructure.rdbms;
 
 import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.user.domain.model.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BlockJpaRepository extends JpaRepository<Block, Long> {
+
+    // 직계 자식들의 부모 변경
+    @Modifying
+    @Query("UPDATE Block b SET b.parent = :newParent WHERE b.parent = :oldParent")
+    void updateChildrenParent(@Param("oldParent") Block oldParent, @Param("newParent") Block newParent);
+
+    long countByParentIsNullAndUser(User user);
+
+    // 시퀀스 조정 (부모가 있을 때)
+    @Modifying
+    @Query("UPDATE Block b SET b.sequence = b.sequence + :offset " +
+            "WHERE b.user = :user AND b.parent = :parent AND b.sequence > :seq")
+    void updateSequenceWithParent(@Param("user") User user, @Param("parent") Block parent,@Param("seq") int seq, @Param("offset") int offset);
+
+    // 시퀀스 조정 (최상위 블록일 때)
+    @Modifying
+    @Query("UPDATE Block b SET b.sequence = b.sequence + :offset " +
+            "WHERE b.user = :user AND b.parent IS NULL AND b.sequence > :seq")
+    void updateSequenceRoot(@Param("user") User user, @Param("seq") int seq, @Param("offset") int offset);
+
+    @Query("SELECT b FROM Block b " +
+            "LEFT JOIN FETCH b.children " +
+            "WHERE b.id = :blockId")
+    Optional<Block> findByIdWithChildren(Long blockId);
+
+    @Modifying
+    @Query("UPDATE Block b SET b.depth = b.depth - 1 " +
+            "WHERE b.user = :user AND b.id IN :ids")
+    void decreaseDepthByIds(@Param("user") User user, @Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockJpaRepository.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockJpaRepository.java
@@ -19,8 +19,6 @@ public interface BlockJpaRepository extends JpaRepository<Block, Long> {
     @Query("UPDATE Block b SET b.parent = :newParent WHERE b.parent = :oldParent")
     void updateChildrenParent(@Param("oldParent") Block oldParent, @Param("newParent") Block newParent);
 
-    long countByParentIsNullAndUser(User user);
-
     // 시퀀스 조정 (부모가 있을 때)
     @Modifying
     @Query("UPDATE Block b SET b.sequence = b.sequence + :offset " +
@@ -38,8 +36,4 @@ public interface BlockJpaRepository extends JpaRepository<Block, Long> {
             "WHERE b.id = :blockId")
     Optional<Block> findByIdWithChildren(Long blockId);
 
-    @Modifying
-    @Query("UPDATE Block b SET b.depth = b.depth - 1 " +
-            "WHERE b.user = :user AND b.id IN :ids")
-    void decreaseDepthByIds(@Param("user") User user, @Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
@@ -82,11 +82,6 @@ public class BlockRepositoryImpl implements BlockRepository {
     }
 
     @Override
-    public long countByParentIsNullAndUser(User user) {
-        return blockJpaRepository.countByParentIsNullAndUser(user);
-    }
-
-    @Override
     public void updateSequenceWithParent(User user, Block parent, int seq, int offset) {
         blockJpaRepository.updateSequenceWithParent(user, parent, seq, offset);
     }
@@ -101,9 +96,5 @@ public class BlockRepositoryImpl implements BlockRepository {
         return blockJpaRepository.findByIdWithChildren(blockId);
     }
 
-    @Override
-    public void decreaseDepthByIds(User user, List<Long> allDescendantIds) {
-        blockJpaRepository.decreaseDepthByIds(user, allDescendantIds);
-    }
 
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
@@ -4,12 +4,14 @@ import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.block.infrastructure.queryDsl.BlockQueryDslRepository;
 import com.joojoo.api.block.infrastructure.queryDsl.date.blockQueryDslDateRepository;
+import com.joojoo.api.user.domain.model.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -57,6 +59,51 @@ public class BlockRepositoryImpl implements BlockRepository {
     @Override
     public List<Block> getBlocksByTagId(Long userId, Long tagId, Long lastBlockId, int limit) {
         return blockQueryDslRepository.getBlocksByTagId(userId, tagId, lastBlockId, limit);
+    }
+
+    @Override
+    public Optional<Block> findById(Long blockId) {
+        return blockJpaRepository.findById(blockId);
+    }
+
+    @Override
+    public void delete(Block targetBlock) {
+        blockJpaRepository.delete(targetBlock);
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(List<Long> idsToDelete) {
+        blockJpaRepository.deleteAllByIdInBatch(idsToDelete);
+    }
+
+    @Override
+    public void updateChildrenParent(Block targetBlock, Block parentBlock) {
+        blockJpaRepository.updateChildrenParent(targetBlock, parentBlock);
+    }
+
+    @Override
+    public long countByParentIsNullAndUser(User user) {
+        return blockJpaRepository.countByParentIsNullAndUser(user);
+    }
+
+    @Override
+    public void updateSequenceWithParent(User user, Block parent, int seq, int offset) {
+        blockJpaRepository.updateSequenceWithParent(user, parent, seq, offset);
+    }
+
+    @Override
+    public void updateSequenceRoot(User user, int seq, int offset) {
+        blockJpaRepository.updateSequenceRoot(user, seq, offset);
+    }
+
+    @Override
+    public Optional<Block> findByIdWithChildren(Long blockId) {
+        return blockJpaRepository.findByIdWithChildren(blockId);
+    }
+
+    @Override
+    public void decreaseDepthByIds(User user, List<Long> allDescendantIds) {
+        blockJpaRepository.decreaseDepthByIds(user, allDescendantIds);
     }
 
 }

--- a/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
+++ b/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.block.presentation.controller;
 
 import com.joojoo.api.block.application.BlockService;
+import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
@@ -82,6 +83,34 @@ public class BlockController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate
     ) {
         return BaseResponse.ok(blockService.getBlockMainView(user.getUserId(), lastDate));
+    }
+
+    @Operation(summary = "블럭(노트) 삭제 API", description = "블럭 삭제 API입니다. 부모만 삭제하면 자식들이 한단계식 승급을하는 형식입니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = BlockDetailResponseDto.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "승격될 자식 블록이 한도(3개)를 초과합니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 블록에 대한 권한이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @DeleteMapping("/delete/{blockId}")
+    public BaseResponse<String> deleteBlock(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long blockId,
+            @RequestParam(defaultValue = "SINGLE") DeleteMode mode
+    ) {
+        blockService.deleteBlock(user.getUserId(), blockId, mode);
+        return BaseResponse.ok("삭제 성공!");
     }
 
 }

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -49,7 +49,8 @@ public enum ErrorCode {
     INVALID_ROOT_BLOCK_COUNT(400, "INVALID_ROOT_BLOCK_COUNT", "최상위 블록(부모)은 반드시 1개여야 합니다."),
     MAX_BLOCK_DEPTH_EXCEEDED(400, "MAX_BLOCK_DEPTH_EXCEEDED", "블록 계층은 최대 2단계(Depth 2)까지만 허용됩니다."),
     BLOCK_NOT_FOUND(404, "BLOCK_NOT_FOUND", "해당 블록을 찾을 수 없습니다."),
-
+    BLOCK_FORBIDDEN_ACCESS(403, "BLOCK_FORBIDDEN_ACCESS", "해당 블록에 대한 권한이 없습니다."),
+    BLOCK_PROMOTION_LIMIT_EXCEEDED(401, "BLOCK_PROMOTION_LIMIT_EXCEEDED", "승격될 자식 블록이 한도(3개)를 초과합니다."),
     ;
 
     private final int httpStatus;

--- a/src/main/java/com/joojoo/global/exception/handleException/block/BlockOwnerMismatchException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/block/BlockOwnerMismatchException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.block;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class BlockOwnerMismatchException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.BLOCK_FORBIDDEN_ACCESS;
+
+    public BlockOwnerMismatchException() {
+        super(errorCode);
+    }
+
+    public BlockOwnerMismatchException(Exception exception) {
+        super(errorCode, exception);
+    }
+}

--- a/src/main/java/com/joojoo/global/exception/handleException/block/BlockPromotionLimitExceededException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/block/BlockPromotionLimitExceededException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.block;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class BlockPromotionLimitExceededException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.BLOCK_PROMOTION_LIMIT_EXCEEDED;
+
+    public BlockPromotionLimitExceededException() {
+        super(errorCode);
+    }
+
+    public BlockPromotionLimitExceededException(Exception exception) {
+        super(errorCode, exception);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 블록 삭제 모드(단일 삭제 후 승격 / 재귀 삭제) 기능 구현 및 계층 구조 자동 조정 로직 추가

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

블록 삭제 시 사용자의 선택에 따라 해당 블록만 삭제하고 자식들을 한 단계 승격시키거나, 하위 트리를 모두 삭제하는 기능을 구현했습니다. 이 과정에서 발생하는 계층 구조(Depth)와 순서(Sequence)의 불일치를 자동으로 조정하는 로직을 포함합니다.

---

## 작업 내용

- 삭제 모드(DeleteMode) 분기 처리
  - ALL: handleRecursiveDelete를 통해 대상 블록과 모든 하위 자손을 일괄 삭제합니다.
  - SINGLE: handleSingleDeleteWithPromotion을 통해 대상 블록만 삭제하고, 직계 자식들을 기존 부모의 위치로 승격시킵니다.

- 계층 구조 자동 조정 로직
  - shiftSiblings: 블록 삭제/승격 시 영향을 받는 형제 블록들의 시퀀스를 벌크 연산으로 일괄 조정합니다.
  - promote: 승격되는 자식 블록들의 새로운 부모 설정 및 시퀀스 재할당을 수행합니다.
  - updateDepthRecursive: 승격된 블록을 포함한 하위 모든 자손의 depth를 재귀적으로 갱신합니다.

- 영속성 컨텍스트 정합성 유지
  - 벌크 연산(UPDATE 쿼리)과 JPA Dirty Checking을 혼용할 때 발생할 수 있는 데이터 불일치를 방지하기 위해, 승격 대상 객체들의 상태를 직접 변경하고 연관관계를 명시적으로 정리(disconnectChildren)합니다.

---

## 관련 이슈

