### PR TITLE
feat: 블럭(노트) 수정 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockService.java
@@ -2,6 +2,7 @@ package com.joojoo.api.block.application;
 
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.block.presentation.dto.response.mainView.BlockMainViewResponse;
@@ -16,4 +17,6 @@ public interface BlockService {
     BlockMainViewResponse getBlockMainView(Long userId, LocalDate lastDate);
 
     void deleteBlock(Long userId, Long blockId, DeleteMode mode);
+
+    void updateBlock(Long userId, Long blockId, BlockUpdateDto blockUpdateDto);
 }

--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -8,6 +8,7 @@ import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.block.presentation.dto.response.mainView.BlockMainViewResponse;
@@ -104,6 +105,17 @@ public class BlockServiceImpl implements BlockService {
         } else {
             handleSingleDeleteWithPromotion(targetBlock);
         }
+    }
+
+    @Override
+    @Transactional
+    public void updateBlock(Long userId, Long blockId, BlockUpdateDto blockUpdateDto) {
+        Block targetBlock = blockRepository.findByIdWithChildren(blockId)
+                .orElseThrow(BlockNotFoundException::new);
+        blockTreeValidator.validateOwner(targetBlock, userId);
+
+        targetBlock.updateContent(blockUpdateDto.getContent());
+        metadataService.processMetadata(targetBlock, userId);
     }
 
     /** 자식들 시퀀스 앞으로 댕기고 삭제 */

--- a/src/main/java/com/joojoo/api/block/application/metadata/MetadataService.java
+++ b/src/main/java/com/joojoo/api/block/application/metadata/MetadataService.java
@@ -11,4 +11,5 @@ public interface MetadataService {
     Map<Block, List<MatchedMetadataDto>> scanBlocks(List<Block> allBlocks, Set<String> tickerNames, Set<String> tagNames);
 
     void processMetadata(List<Block> allBlocks, Long userId);
+    void processMetadata(Block targetBlock, Long userId);
 }

--- a/src/main/java/com/joojoo/api/block/application/metadata/MetadataServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/metadata/MetadataServiceImpl.java
@@ -83,6 +83,13 @@ public class MetadataServiceImpl implements MetadataService {
         blockTagRepository.saveAll(blockTags);
     }
 
+    @Override
+    public void processMetadata(Block targetBlock, Long userId) {
+        blockTickerRepository.deleteByBlockIds(targetBlock.getId());
+        blockTagRepository.deleteByBlockIds(targetBlock.getId());
+        this.processMetadata(Collections.singletonList(targetBlock), userId);
+    }
+
     /** 추출된 맵을 바탕으로 BlockTicker, BlockTag 중간 테이블 엔티티 생성 */
     public void mapToEntities(Block block, Long userId, List<MatchedMetadataDto> matches, Map<String, Ticker> tickerMap, Map<String, Tag> tagMap, List<BlockTicker> bTickers, List<BlockTag> bTags) {
         if (block.getContent() == null) return;

--- a/src/main/java/com/joojoo/api/block/domain/model/entity/Block.java
+++ b/src/main/java/com/joojoo/api/block/domain/model/entity/Block.java
@@ -98,4 +98,7 @@ public class Block extends BaseTimeEntity {
         this.children.clear();
     }
 
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
+++ b/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
@@ -3,6 +3,7 @@ package com.joojoo.api.block.presentation.controller;
 import com.joojoo.api.block.application.BlockService;
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.block.presentation.dto.response.mainView.BlockMainViewResponse;
@@ -89,7 +90,7 @@ public class BlockController {
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "조회 성공",
+                    description = "삭제 성공",
                     content = @Content(schema = @Schema(implementation = BlockDetailResponseDto.class))
             ),
             @ApiResponse(
@@ -101,6 +102,11 @@ public class BlockController {
                     responseCode = "403",
                     description = "해당 블록에 대한 권한이 없습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 블록을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     @DeleteMapping("/delete/{blockId}")
@@ -111,6 +117,34 @@ public class BlockController {
     ) {
         blockService.deleteBlock(user.getUserId(), blockId, mode);
         return BaseResponse.ok("삭제 성공!");
+    }
+
+    @Operation(summary = "블럭(노트) 수정 API", description = "블럭(노트) 내용을 수정하는 API입니다. ")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = BlockDetailResponseDto.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 블록에 대한 권한이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 블록을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PatchMapping("/update/{blockId}")
+    public BaseResponse<String> updateBlock(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long blockId,
+            @RequestBody BlockUpdateDto blockUpdateDto
+    ) {
+        blockService.updateBlock(user.getUserId(), blockId, blockUpdateDto);
+        return BaseResponse.ok("수정 성공!");
     }
 
 }

--- a/src/main/java/com/joojoo/api/block/presentation/dto/request/updateBlock/BlockUpdateDto.java
+++ b/src/main/java/com/joojoo/api/block/presentation/dto/request/updateBlock/BlockUpdateDto.java
@@ -1,0 +1,10 @@
+package com.joojoo.api.block.presentation.dto.request.updateBlock;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BlockUpdateDto {
+    private String content;
+}

--- a/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
@@ -14,4 +14,6 @@ public interface BlockTagRepository {
     List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId);
 
     BlockTagCountResponse getBlockCount(Long userId, Long tagId);
+
+    void deleteByBlockIds(Long id);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagJpaRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagJpaRepository.java
@@ -2,10 +2,14 @@ package com.joojoo.api.blockTag.infrastructure.rdbms;
 
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BlockTagJpaRepository extends JpaRepository<BlockTag, Long> {
 
-
+    @Modifying
+    @Query("delete FROM BlockTag bt where bt.block.id = :id")
+    void deleteByBlockIds(Long id);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
@@ -36,4 +36,9 @@ public class BlockTagRepositoryImpl implements BlockTagRepository {
     public BlockTagCountResponse getBlockCount(Long userId, Long tagId) {
         return blockTagQueryDslRepository.getBlockCount(userId, tagId);
     }
+
+    @Override
+    public void deleteByBlockIds(Long id) {
+        blockTagJpaRepository.deleteByBlockIds(id);
+    }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/domain/repository/BlockTickerRepository.java
+++ b/src/main/java/com/joojoo/api/blockTicker/domain/repository/BlockTickerRepository.java
@@ -8,4 +8,6 @@ public interface BlockTickerRepository {
     List<BlockTicker> saveAll(List<BlockTicker> blockTickers);
 
     List<BlockTicker> findAllBlockTickers(List<Long> blockIds);
+
+    void deleteByBlockIds(Long id);
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerJpaRepository.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerJpaRepository.java
@@ -2,8 +2,14 @@ package com.joojoo.api.blockTicker.infrastructure.rdbms;
 
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BlockTickerJpaRepository extends JpaRepository<BlockTicker, Long> {
+
+    @Modifying
+    @Query("delete FROM BlockTag bt where bt.block.id = :id")
+    void deleteByBlockIds(Long id);
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
@@ -24,4 +24,9 @@ public class BlockTickerRepositoryImpl implements BlockTickerRepository {
     public List<BlockTicker> findAllBlockTickers(List<Long> blockIds) {
         return blockTickerQueryDslRepository.findAllBlockTickers(blockIds);
     }
+
+    @Override
+    public void deleteByBlockIds(Long id) {
+        blockTickerJpaRepository.deleteByBlockIds(id);
+    }
 }


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 블록 수정 시 메타데이터(Ticker, Tag) 자동 갱신 로직 구현

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [x] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [ ] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

블록 내용(Content) 수정 시, 텍스트 내 포함된 티커($) 및 태그(#)를 재분석하여 메타데이터 관계를 최신 상태로 유지하는 기능을 구현했습니다.

---

## 작업 내용

- **블록 수정 API 구현 (`updateBlock`)**
  - 블록 소유권 검증 및 내용 업데이트 로직 통합
  - 수정 시 실시간 메타데이터 프로세싱 호출
- **메타데이터 동기화 로직 (`processMetadata`)**
  - **Delete-and-Insert 전략**: 기존 연관 관계(`BlockTicker`, `BlockTag`)를 삭제 후 재등록하여 데이터 정합성 확보
  - **정규식 스캔**: `scanBlocks`를 통한 티커 및 태그 추출
  - **벌크 처리 지원**: 단일 블록뿐만 아니라 리스트 단위(`List<Block>`) 처리 구조 설계로 확장성 고려
- **성능 고려사항 주석 추가**
  - 대량 데이터 처리를 위한 JDBC Batch Insert 검토 필요성 명시

---

## 관련 이슈

