### PR TITLE
fix: 메인 페이지 API 날짜 경계값 오류 수정

### DIFF
--- a/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/date/blockQueryDslDateRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/date/blockQueryDslDateRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.joojoo.api.block.infrastructure.queryDsl.date;
 import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.model.entity.QBlock;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -92,8 +93,8 @@ public class blockQueryDslDateRepositoryImpl implements blockQueryDslDateReposit
 
     private BooleanExpression leLastDate(LocalDate lastDate) {
         if (lastDate == null) return null;
-        // block.createdAt >= 21일 00:00
-        return block.createdAt.loe(lastDate.atTime(LocalTime.MAX));
+        // 해당 날짜(lastDate)의 23:59:59까지
+        return block.createdAt.lt(lastDate.plusDays(1).atStartOfDay());
     }
 
 }


### PR DESCRIPTION
## 📌 PR 제목

- [Fix] 메인 뷰 조회 시 날짜 경계값 오류 수정 및 커서 페이징 최적화

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [x] 버그수정 (Bugfix)
- [ ] 기능개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update)
- [ ] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

메인 뷰 조회 시 lastDate를 기준으로 이전 날짜의 데이터를 가져오는 과정에서, 다음 날짜의 00시 데이터가 포함되던 정렬 및 범위 중복 문제를 해결했습니다.

---

## 작업 내용

- 작업한 주요 내용을 bullet 형식으로 작성해주세요.
- 날짜 범위 조건 수정
  - 기존 loe(atTime(LocalTime.MAX)) 방식에서 발생할 수 있는 다음 날 00:00:00 데이터 포함 문제를 해결하기 위해 lt(plusDays(1).atStartOfDay()) 방식으로 변경했습니다.
  - 재 결과 리스트의 마지막 날짜(oldestDateInResult)보다 확실히 과거인 데이터를 찾도록 lt() 연산자를 적용하여 커서 중복 현상을 방지했습니다.

---

## 관련 이슈

