### PR TITLE
feat: 메모, 템플릿 태그를 따로 저장하여 nativeQuery를 사용해 UNION 적용

### DIFF
--- a/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
@@ -11,6 +11,10 @@ public interface BlockTagRepository {
 
     List<BlockTag> findAllBlockTags(List<Long> blockIds);
 
+    /** 블럭에서만 사용한 최근 태그 조회 */
+    List<RecentTagsResponse.RecentTagsDto> findBlockRecentTags(Long userId);
+
+    /** 블럭, 템플릿에서 사용한 최근 태그 조회 */
     List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId);
 
     BlockTagCountResponse getBlockCount(Long userId, Long tagId);

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagJpaRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagJpaRepository.java
@@ -1,10 +1,13 @@
 package com.joojoo.api.blockTag.infrastructure.rdbms;
 
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.presentation.dto.response.recent.RecentTagsResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface BlockTagJpaRepository extends JpaRepository<BlockTag, Long> {
@@ -12,4 +15,15 @@ public interface BlockTagJpaRepository extends JpaRepository<BlockTag, Long> {
     @Modifying
     @Query("delete FROM BlockTag bt where bt.block.id = :id")
     void deleteByBlockIds(Long id);
+
+    @Query(value =
+            "SELECT t.id AS id, t.name AS name FROM (" +
+                    "  (SELECT tag_id, created_at FROM block_tags WHERE user_id = :userId) " +
+                    "  UNION " +
+                    "  (SELECT tag_id, created_at FROM trade_log_tags WHERE user_id = :userId) " +
+                    ") AS combined_tags " +
+                    "JOIN tags t ON t.id = combined_tags.tag_id " +
+                    "ORDER BY combined_tags.created_at DESC " +
+                    "LIMIT 10", nativeQuery = true)
+    List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
@@ -28,8 +28,13 @@ public class BlockTagRepositoryImpl implements BlockTagRepository {
     }
 
     @Override
-    public List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId) {
+    public List<RecentTagsResponse.RecentTagsDto> findBlockRecentTags(Long userId) {
         return blockTagQueryDslRepository.findRecentTags(userId);
+    }
+
+    @Override
+    public List<RecentTagsResponse.RecentTagsDto> findRecentTags(Long userId) {
+        return blockTagJpaRepository.findRecentTags(userId);
     }
 
     @Override


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 최근 사용 태그 통합 조회 기능 구현 (Native Query)

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## PR Type

해당 PR의 성격을 체크해주세요.

- [ ] 버그수정 (Bugfix)
- [ ] 기능개발 (Feature)
- [x] 코드 스타일 변경 (Code style update)
- [x] 리팩토링 (Refactor)
- [ ] 빌드 관련 변경 (Build system)
- [ ] 문서 내용 변경 (Docs)
- [ ] 커밋 되돌리기 (Revert)
- [ ] 기타 :

---

## 작업 개요

Block과 TradeLog로 분리된 태그 사용 이력을 통합하여 사용자가 최근에 사용한 태그 10개를 조회하는 기능을 구현했습니다.

---

## 작업 내용

- Native Query를 활용한 통합 조회
  - UNION 연산을 통해 block_tags와 trade_log_tags 테이블의 데이터를 합쳐 최신순으로 정렬하도록 구현했습니다.

---

## 관련 이슈

- 관련된 이슈 번호를 적어주세요. `#번호`
