### PR TITLE
refactor: 수정된 엔티티에 맞게 MetadataService 수정

### DIFF
--- a/src/main/java/com/joojoo/api/blockTag/domain/model/entity/BlockTag.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/model/entity/BlockTag.java
@@ -66,4 +66,15 @@ public class BlockTag extends BaseCreateEntity {
                 .fieldType(fieldType)
                 .build();
     }
+
+    public static BlockTag create(TradeLog tradeLog, Tag tag, Long userId, TagSourceType fieldType, Integer startOffset, Integer sequence) {
+        return BlockTag.builder()
+                .tradeLog(tradeLog)
+                .tag(tag)
+                .userId(userId)
+                .fieldType(fieldType)
+                .startOffset(startOffset)
+                .sequence(sequence)
+                .build();
+    }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/domain/model/entity/BlockTicker.java
+++ b/src/main/java/com/joojoo/api/blockTicker/domain/model/entity/BlockTicker.java
@@ -46,9 +46,10 @@ public class BlockTicker extends BaseCreateEntity {
     private Integer startOffset;
 
     @Builder
-    public BlockTicker(Block block, Ticker ticker, Long userId, TagSourceType fieldType, Integer sequence, Integer startOffset) {
+    public BlockTicker(Block block, Ticker ticker, TradeLog tradeLog, Long userId, TagSourceType fieldType, Integer sequence, Integer startOffset) {
         this.block = block;
         this.ticker = ticker;
+        this.tradeLog = tradeLog;
         this.userId = userId;
         this.fieldType = fieldType;
         this.sequence = sequence;
@@ -63,6 +64,17 @@ public class BlockTicker extends BaseCreateEntity {
                 .sequence(tSeq)
                 .startOffset(start)
                 .fieldType(fieldType)
+                .build();
+    }
+
+    public static BlockTicker create(TradeLog tradeLog, Ticker ticker, Long userId, TagSourceType fieldType, Integer startOffset, Integer sequence) {
+        return BlockTicker.builder()
+                .tradeLog(tradeLog)
+                .ticker(ticker)
+                .userId(userId)
+                .fieldType(fieldType)
+                .startOffset(startOffset)
+                .sequence(sequence)
                 .build();
     }
 }

--- a/src/main/java/com/joojoo/api/tradeLog/application/TradeLogServiceImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/TradeLogServiceImpl.java
@@ -37,7 +37,7 @@ public class TradeLogServiceImpl implements TradeLogService {
         TradeLog tradeLog = TradeLog.create(user, ticker, tradeRequestDto);
 
         TradeLog save = tradeLogRepository.save(tradeLog);
-//        metadataService.processTradeLogMetadata(save, userId);
+        metadataService.processTradeLogMetadata(save, userId);
     }
 
 }

--- a/src/main/java/com/joojoo/api/util/metadata/MetadataService.java
+++ b/src/main/java/com/joojoo/api/util/metadata/MetadataService.java
@@ -13,5 +13,5 @@ public interface MetadataService {
     void processMetadata(Block targetBlock, Long userId);
 
     /** TradeLog 타입으로 티커, 태그 찾기 */
-//    void processTradeLogMetadata(TradeLog tradeLog, Long userId);
+    void processTradeLogMetadata(TradeLog tradeLog, Long userId);
 }

--- a/src/main/java/com/joojoo/api/util/metadata/MetadataServiceImpl.java
+++ b/src/main/java/com/joojoo/api/util/metadata/MetadataServiceImpl.java
@@ -10,6 +10,7 @@ import com.joojoo.api.tag.application.in.TagInService;
 import com.joojoo.api.tag.domain.model.entity.Tag;
 import com.joojoo.api.ticker.application.in.TickerInService;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 import com.joojoo.global.common.enums.TagSourceType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -77,47 +78,51 @@ public class MetadataServiceImpl implements MetadataService {
         this.processMetadata(Collections.singletonList(targetBlock), userId);
     }
 
-//    @Override
-//    public void processTradeLogMetadata(TradeLog tradeLog, Long userId) {
-//        MetadataContext context = new MetadataContext();
-//
-//        Map<String, String> sources = new LinkedHashMap<>();
-//        sources.put("MEMO", tradeLog.getMemo());
-//        sources.put("RISK", tradeLog.getRiskFactor());
-//        sources.put("PLAN", tradeLog.getTradingPlan());
-//
-//        Map<String, List<MatchedMetadataDto>> analysisResults = new HashMap<>();
-//        sources.forEach((field, content) -> {
-//            if (content != null) {
-//                analysisResults.put(field, scanContent(content, context));
-//            }
-//        });
-//
-//        context.loadEntities(tickerInService, tagInService);
-//
-//        List<TradeLogTicker> tlTickers = new ArrayList<>();
-//        List<TradeLogTag> tlTags = new ArrayList<>();
-//
-//        analysisResults.forEach((field, matches) -> {
-//            int tSeq = 0, tagSeq = 0;
-//            for (MatchedMetadataDto match : matches) {
-//                if (match.isTicker()) {
-//                    Ticker ticker = context.getTicker(match.name());
-//                    if (ticker != null) {
-//                        tlTickers.add(TradeLogTicker.create(tradeLog, ticker, userId, field, match.start(), tSeq++));
-//                    }
-//                } else {
-//                    Tag tag = context.getTag(match.name());
-//                    if (tag != null) {
-//                        tlTags.add(TradeLogTag.create(tradeLog, tag, userId, field, match.start(), tagSeq++));
-//                    }
-//                }
-//            }
-//        });
-//
-//        if (!tlTickers.isEmpty()) tradeLogTickerRepository.saveAll(tlTickers);
-//        if (!tlTags.isEmpty()) tradeLogTagRepository.saveAll(tlTags);
-//    }
+    @Override
+    public void processTradeLogMetadata(TradeLog tradeLog, Long userId) {
+        MetadataContext context = new MetadataContext();
+
+        // 1. 소스 필드와 Enum 매핑
+        Map<TagSourceType, String> sources = new LinkedHashMap<>();
+        sources.put(TagSourceType.TRADE_MEMO, tradeLog.getMemo());
+        sources.put(TagSourceType.TRADE_RISK, tradeLog.getRiskFactor());
+        sources.put(TagSourceType.TRADE_PLAN, tradeLog.getTradingPlan());
+
+        // 2. 스캔 결과 수집
+        Map<TagSourceType, List<MatchedMetadataDto>> analysisResults = new HashMap<>();
+        sources.forEach((type, content) -> {
+            if (content != null && !content.isBlank()) {
+                analysisResults.put(type, scanContent(content, context));
+            }
+        });
+
+        context.loadEntities(tickerInService, tagInService);
+
+        List<BlockTicker> tlTickers = new ArrayList<>();
+        List<BlockTag> tlTags = new ArrayList<>();
+
+        // 3. 엔티티 생성
+        analysisResults.forEach((type, matches) -> {
+            int tSeq = 0, tagSeq = 0;
+            for (MatchedMetadataDto match : matches) {
+                if (match.isTicker()) {
+                    Ticker ticker = context.getTicker(match.name());
+                    if (ticker != null) {
+                        // tradeLog를 인자로 받는 create 메서드 호출
+                        tlTickers.add(BlockTicker.create(tradeLog, ticker, userId, type, match.start(), tSeq++));
+                    }
+                } else {
+                    Tag tag = context.getTag(match.name());
+                    if (tag != null) {
+                        tlTags.add(BlockTag.create(tradeLog, tag, userId, type, match.start(), tagSeq++));
+                    }
+                }
+            }
+        });
+
+        if (!tlTickers.isEmpty()) blockTickerRepository.saveAll(tlTickers);
+        if (!tlTags.isEmpty()) blockTagRepository.saveAll(tlTags);
+    }
 
     /** 텍스트에서 메타데이터 추출 및 컨텍스트에 이름 수집 */
     private List<MatchedMetadataDto> scanContent(String content, MetadataContext context) {

--- a/src/main/java/com/joojoo/global/exception/handleException/tickers/TickerNotFoundException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/tickers/TickerNotFoundException.java
@@ -4,7 +4,7 @@ import com.joojoo.global.exception.ServiceException;
 import com.joojoo.global.exception.enums.ErrorCode;
 
 public class TickerNotFoundException extends ServiceException {
-    private static final ErrorCode errorCode = ErrorCode.USER_NOT_FOUND;
+    private static final ErrorCode errorCode = ErrorCode.TICKER_NOT_FOUND;
 
     public TickerNotFoundException() {
         super(errorCode);


### PR DESCRIPTION
분리되어있던 중계 테이블을 합치게 되면서 기존 MetadataService 클래스의 중계 테이블 저장 부분을 변경된 Entity에 맞게 수정하였습니다!