### PR TITLE
feat: 티커 상세 페이지 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/blockTag/application/test/QueryDsl.java
+++ b/src/main/java/com/joojoo/api/blockTag/application/test/QueryDsl.java
@@ -1,31 +1,23 @@
 package com.joojoo.api.blockTag.application.test;
 
-import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.model.entity.QBlock;
-import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTag.domain.model.entity.QBlockTag;
-import com.joojoo.api.blockTag.presentation.dto.response.all.BlockDetailMode;
 import com.joojoo.api.blockTag.presentation.dto.response.all.TagDateResult;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import com.joojoo.api.blockTicker.domain.model.entity.QBlockTicker;
-import com.joojoo.api.tag.domain.model.entity.QTag;
+import com.joojoo.api.blockTicker.presentation.dto.request.TickerDateResult;
 import com.joojoo.api.ticker.domain.model.entity.QTicker;
 import com.joojoo.api.tradeLog.domain.model.entity.QTradeLog;
-import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
-import com.joojoo.api.user.domain.model.entity.QUser;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
@@ -106,5 +98,54 @@ public class QueryDsl {
                 .join(blockTicker.ticker, ticker).fetchJoin()
                 .where(blockTicker.tradeLog.id.in(tradeLogIds))
                 .fetch();
+    }
+
+    public TickerDateResult findAllByTickerAndDate(Long userId, Long tickerId, LocalDate targetDate) {
+        int dateCount = 3;
+        List<LocalDate> targetDates = getTargetTickerDates(userId, tickerId, targetDate, dateCount);
+
+        if (targetDates.isEmpty()) return new TickerDateResult(Collections.emptyList(), targetDates);
+
+        // 조회된 날짜에서 가장 과거 날짜
+        LocalDate minDate = targetDates.get(targetDates.size() - 1);
+
+        // 실제 데이터 조회
+        List<BlockTicker> content = queryFactory
+                .selectFrom(blockTicker)
+                .leftJoin(blockTicker.block, block).fetchJoin()
+                .leftJoin(blockTicker.tradeLog, tradeLog).fetchJoin()
+                .where(
+                        blockTicker.ticker.id.eq(tickerId),
+                        blockTicker.userId.eq(userId),
+                        blockTicker.createdAt.goe(minDate.atStartOfDay()),
+                        leLastTickerDate(targetDate)
+                )
+                .orderBy(blockTicker.createdAt.desc())
+                .fetch();
+
+        return new TickerDateResult(content, targetDates);
+    }
+
+    private List<LocalDate> getTargetTickerDates(Long userId, Long tickerId, LocalDate lastDate, int dateCount) {
+        return queryFactory
+                .select(blockTicker.createdAt)
+                .from(blockTicker)
+                .where(
+                        blockTicker.ticker.id.eq(tickerId),
+                        blockTicker.userId.eq(userId),
+                        leLastTickerDate(lastDate)
+                )
+                .orderBy(blockTicker.createdAt.desc())
+                .fetch()
+                .stream()
+                .map(LocalDateTime::toLocalDate)
+                .distinct()
+                .limit(dateCount)
+                .toList();
+    }
+
+    private BooleanExpression leLastTickerDate(LocalDate lastDate) {
+        if (lastDate == null) return null;
+        return blockTicker.createdAt.lt(lastDate.plusDays(1).atStartOfDay());
     }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/presentation/dto/request/TickerDateResult.java
+++ b/src/main/java/com/joojoo/api/blockTicker/presentation/dto/request/TickerDateResult.java
@@ -1,0 +1,15 @@
+package com.joojoo.api.blockTicker.presentation.dto.request;
+
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TickerDateResult {
+    private List<BlockTicker> content;
+    private List<LocalDate> targetDates;
+}

--- a/src/main/java/com/joojoo/api/ticker/application/TickerService.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerService.java
@@ -1,6 +1,9 @@
 package com.joojoo.api.ticker.application;
 
+import com.joojoo.api.blockTag.presentation.dto.response.detail.BlockTagsResponse;
 import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;
+
+import java.time.LocalDate;
 
 public interface TickerService {
     void addStockToRedis(String name, String ticker);
@@ -12,4 +15,6 @@ public interface TickerService {
 
     // 운영 DB에 있는 주식을 Redis에 저장
     void loadTickersToCache(Long userId);
+
+    BlockTagsResponse getTickerList(Long userId, Long tickerId, LocalDate lastDate);
 }

--- a/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
@@ -1,13 +1,21 @@
 package com.joojoo.api.ticker.application;
 
+import com.joojoo.api.block.application.validate.blockerTree.BlockTreeValidator;
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.blockTag.application.test.QueryDsl;
+import com.joojoo.api.blockTag.presentation.dto.response.detail.BlockTagsResponse;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.blockTicker.presentation.dto.request.TickerDateResult;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.ticker.domain.provider.TickerDataProvider;
 import com.joojoo.api.ticker.domain.repository.TickerRedisRepository;
 import com.joojoo.api.ticker.domain.repository.TickerRepository;
 import com.joojoo.api.ticker.presentation.dto.request.TickerDataDto;
 import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;
+import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
+import com.joojoo.api.util.detailQuery.BlockTradeLogQueryService;
 import com.joojoo.global.exception.handleException.tickers.InvalidTickerOrNameException;
 import com.joojoo.global.exception.handleException.users.UserNotFoundException;
 import com.joojoo.global.util.HangulUtils;
@@ -19,6 +27,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -33,6 +43,9 @@ public class TickerServiceImpl implements TickerService {
     private final TickerRepository tickerRepository;
     private final TickerDataProvider tickerDataProvider;
     private final UserRepository userRepository;
+    private final BlockTradeLogQueryService blockTradeLogQueryService;
+    private final BlockTreeValidator blockTreeValidator;
+    private final QueryDsl queryDsl;
 
     @Override
     public void addStockToRedis(String name, String ticker) {
@@ -98,6 +111,39 @@ public class TickerServiceImpl implements TickerService {
             tickerRedisRepository.addStocksToRedis(tickers);
         }
         log.info("티커 Cache 업데이트 완료: {}건 처리됨", tickers.size());
+    }
+
+    @Override
+    public BlockTagsResponse getTickerList(Long userId, Long tickerId, LocalDate lastDate) {
+        LocalDate targetDate = blockTreeValidator.validateAndGetTargetDate(lastDate);
+        TickerDateResult result = queryDsl.findAllByTickerAndDate(userId, tickerId, targetDate);
+
+        if (result.getContent().isEmpty()) {
+            return BlockTagsResponse.of(Collections.emptyList(), false, null);
+        }
+
+        List<LocalDate> displayDates = result.getTargetDates().stream().limit(2).toList();
+
+        // 필터링된 Block과 TradeLog 추출
+        List<Block> blocks = result.getContent().stream()
+                .filter(bt -> displayDates.contains(getCreatedAt(bt).toLocalDate()))
+                .map(BlockTicker::getBlock)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        List<TradeLog> tradeLogs = result.getContent().stream()
+                .filter(bt -> displayDates.contains(getCreatedAt(bt).toLocalDate()))
+                .map(BlockTicker::getTradeLog)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        return blockTradeLogQueryService.assembleBlockTagsResponse(result.getTargetDates(), blocks, tradeLogs);
+    }
+
+    private LocalDateTime getCreatedAt(BlockTicker bt) {
+        return (bt.getBlock() != null) ? bt.getBlock().getCreatedAt() : bt.getTradeLog().getCreatedAt();
     }
 
     private Stream<String> generateSearchKeywords(Ticker stock) {

--- a/src/main/java/com/joojoo/api/ticker/presentation/controller/TickerController.java
+++ b/src/main/java/com/joojoo/api/ticker/presentation/controller/TickerController.java
@@ -1,5 +1,6 @@
 package com.joojoo.api.ticker.presentation.controller;
 
+import com.joojoo.api.blockTag.presentation.dto.response.detail.BlockTagsResponse;
 import com.joojoo.api.ticker.application.TickerService;
 import com.joojoo.api.ticker.presentation.dto.response.TickerSearchResponse;
 import com.joojoo.global.common.request.auth.CustomUserDetails;
@@ -13,8 +14,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,7 +26,6 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Ticker API", description = "주식 티커 관련 API")
 public class TickerController {
     private final TickerService tickerService;
-
 
     @Operation(summary = "주식 티커 추가 (검색 확인용)", description = "Redis에 새로운 주식 이름과 티커 심볼을 저장합니다.")
     @ApiResponses(value = {
@@ -56,5 +59,18 @@ public class TickerController {
     @PostMapping("/load-Cache")
     public void dbToRedis(@AuthenticationPrincipal CustomUserDetails user){
         tickerService.loadTickersToCache(user.getUserId());
+    }
+
+    @Operation(summary = "티커 상세 API", description = "특정 티커를 조회하여 Block, TradeLog에 작성한 티커를 가져옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/{tickerId}")
+    public BaseResponse<BlockTagsResponse> getTickerList(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long tickerId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate
+    ){
+        return BaseResponse.ok(tickerService.getTickerList(user.getUserId(), tickerId, lastDate));
     }
 }

--- a/src/main/java/com/joojoo/api/tradeLog/application/TradeLogServiceImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/TradeLogServiceImpl.java
@@ -37,7 +37,7 @@ public class TradeLogServiceImpl implements TradeLogService {
         TradeLog tradeLog = TradeLog.create(user, ticker, tradeRequestDto);
 
         TradeLog save = tradeLogRepository.save(tradeLog);
-        metadataService.processTradeLogMetadata(save, userId);
+        metadataService.processTradeLogMetadata(save, userId, ticker);
     }
 
 }

--- a/src/main/java/com/joojoo/api/util/detailQuery/BlockTradeLogQueryService.java
+++ b/src/main/java/com/joojoo/api/util/detailQuery/BlockTradeLogQueryService.java
@@ -1,0 +1,12 @@
+package com.joojoo.api.util.detailQuery;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.blockTag.presentation.dto.response.detail.BlockTagsResponse;
+import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface BlockTradeLogQueryService {
+    BlockTagsResponse assembleBlockTagsResponse(List<LocalDate> targetDates, List<Block> blocks, List<TradeLog> tradeLogs);
+}

--- a/src/main/java/com/joojoo/api/util/detailQuery/BlockTradeLogQueryServiceImpl.java
+++ b/src/main/java/com/joojoo/api/util/detailQuery/BlockTradeLogQueryServiceImpl.java
@@ -1,0 +1,85 @@
+package com.joojoo.api.util.detailQuery;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.domain.repository.BlockRepository;
+import com.joojoo.api.blockTag.application.test.QueryDsl;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.blockTag.presentation.dto.response.all.BlockDetailMode;
+import com.joojoo.api.blockTag.presentation.dto.response.all.DailyGroupResponseDto;
+import com.joojoo.api.blockTag.presentation.dto.response.all.TradeLogResponseDto;
+import com.joojoo.api.blockTag.presentation.dto.response.detail.BlockTagsResponse;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
+import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BlockTradeLogQueryServiceImpl implements BlockTradeLogQueryService {
+
+    private final BlockTagRepository blockTagRepository;
+    private final BlockTickerRepository blockTickerRepository;
+    private final BlockRepository blockRepository;
+    private final QueryDsl queryDsl;
+
+    @Override
+    public BlockTagsResponse assembleBlockTagsResponse(List<LocalDate> targetDates, List<Block> allBlocks, List<TradeLog> allTradeLogs) {
+        /** 조회할 Block, TradeLog ID들 추출 */
+        List<Long> blockIds = allBlocks.stream().map(Block::getId).toList();
+        List<Long> tradeLogIds = allTradeLogs.stream().map(TradeLog::getId).toList();
+
+        // 연관 데이터 일괄 조회
+        /** blockId 로 연관퇸 블럭 태그들 조회 */
+        Map<Long, List<BlockTag>> tagsByBlockId = blockTagRepository.findAllBlockTags(blockIds).stream()
+                .collect(Collectors.groupingBy(bt -> bt.getBlock().getId()));
+
+        /** blockId 로 연관퇸 블럭 티커들 조회 */
+        Map<Long, List<BlockTicker>> tickersByBlockId = blockTickerRepository.findAllBlockTickers(blockIds).stream()
+                .collect(Collectors.groupingBy(bt -> bt.getBlock().getId()));
+
+        /** 조회한 블럭의 자식 갯수 */
+        Map<Long, Long> childCounts = blockRepository.getChildCounts(blockIds);
+
+        /** tradeLogId 로 연관퇸 템플릿 태그들 조회 */
+        Map<Long, List<BlockTag>> tagsByTradeLogId = queryDsl.findAllByTradeLogIds(tradeLogIds).stream()
+                .collect(Collectors.groupingBy(bt -> bt.getTradeLog().getId()));
+
+        /** tradeLogId 로 연관퇸 템플릿 티커들 조회 */
+        Map<Long, List<BlockTicker>> tickerByTradeLogId = queryDsl.findAllTickersByTradeLogIds(tradeLogIds).stream()
+                .collect(Collectors.groupingBy(bt -> bt.getTradeLog().getId()));
+
+        /** 날짜별 그룹화하여 블럭 모음 */
+        Map<LocalDate, List<BlockDetailMode>> groupedBlocks = allBlocks.stream()
+                .map(b -> BlockDetailMode.from(b,
+                        tagsByBlockId.getOrDefault(b.getId(), Collections.emptyList()),
+                        tickersByBlockId.getOrDefault(b.getId(), Collections.emptyList()),
+                        childCounts.getOrDefault(b.getId(), 0L)))
+                .collect(Collectors.groupingBy(dto -> dto.getCreatedAt().toLocalDate()));
+
+        /** 날짜별 그룹화하여 TradeLog 모음 */
+        Map<LocalDate, List<TradeLogResponseDto>> groupedTradeLogs = allTradeLogs.stream()
+                .map(log -> TradeLogResponseDto.from(log,
+                        tagsByTradeLogId.getOrDefault(log.getId(), Collections.emptyList()),
+                        tickerByTradeLogId.getOrDefault(log.getId(), Collections.emptyList())
+                ))
+                .collect(Collectors.groupingBy(dto -> dto.getCreatedAt().toLocalDate()));
+
+        List<DailyGroupResponseDto> dailyGroups = targetDates.stream()
+                .limit(2)
+                .map(date -> DailyGroupResponseDto.of(date, groupedBlocks, groupedTradeLogs))
+                .toList();
+
+        boolean hasNext = targetDates.size() > 2;
+        LocalDate nextDate = hasNext ? targetDates.get(2) : null;
+
+        return BlockTagsResponse.of(dailyGroups, hasNext, nextDate);
+    }
+}

--- a/src/main/java/com/joojoo/api/util/metadata/MetadataService.java
+++ b/src/main/java/com/joojoo/api/util/metadata/MetadataService.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.util.metadata;
 
 import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 
 import java.util.List;
@@ -13,5 +14,5 @@ public interface MetadataService {
     void processMetadata(Block targetBlock, Long userId);
 
     /** TradeLog 타입으로 티커, 태그 찾기 */
-    void processTradeLogMetadata(TradeLog tradeLog, Long userId);
+    void processTradeLogMetadata(TradeLog tradeLog, Long userId, Ticker ticker);
 }

--- a/src/main/java/com/joojoo/api/util/metadata/MetadataServiceImpl.java
+++ b/src/main/java/com/joojoo/api/util/metadata/MetadataServiceImpl.java
@@ -79,7 +79,7 @@ public class MetadataServiceImpl implements MetadataService {
     }
 
     @Override
-    public void processTradeLogMetadata(TradeLog tradeLog, Long userId) {
+    public void processTradeLogMetadata(TradeLog tradeLog, Long userId, Ticker mainTicker) {
         MetadataContext context = new MetadataContext();
 
         // 1. 소스 필드와 Enum 매핑
@@ -100,6 +100,15 @@ public class MetadataServiceImpl implements MetadataService {
 
         List<BlockTicker> tlTickers = new ArrayList<>();
         List<BlockTag> tlTags = new ArrayList<>();
+
+        tlTickers.add(BlockTicker.create(
+                tradeLog,
+                mainTicker,
+                userId,
+                TagSourceType.TRADE_HEADER,
+                -1, // 본문 내 위치가 아님을 표시
+                0
+        ));
 
         // 3. 엔티티 생성
         analysisResults.forEach((type, matches) -> {

--- a/src/main/java/com/joojoo/global/common/enums/TagSourceType.java
+++ b/src/main/java/com/joojoo/global/common/enums/TagSourceType.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum TagSourceType {
     BLOCK_CONTENT("블록 내용"),
+    TRADE_HEADER("거래내역 용"),
     TRADE_MEMO("매매 근거"),
     TRADE_RISK("리스크 요소"),
     TRADE_PLAN("매매 계획");


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 티커 상세 페이지 API 구현

---

## 작업 개요

특정 티커를 조회하면 Block과 TradeLog에 사용한 것들을 이틀치 만큼 리스트를 반환합니다.

---

## 작업 내용

- 중계 테이블 조회 후 ID를 추출해 날짜별로 데이터들을 가공
  - `assembleBlockTagsResponse` 클래스 리팩토링 해야 함

---

## 관련 이슈
