### PR TITLE
refactor: 계정 탈퇴 DDD + hexagonal 로 리팩토링

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -1,8 +1,6 @@
 package com.joojoo.api.block.application;
 
 import com.joojoo.api.block.application.detail.BlockDtoAssembler;
-import com.joojoo.api.tag.domain.model.entity.Tag;
-import com.joojoo.api.util.metadata.MetadataService;
 import com.joojoo.api.block.application.validate.blockerTree.BlockTreeValidator;
 import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
@@ -17,10 +15,11 @@ import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
+import com.joojoo.api.tag.domain.model.entity.Tag;
+import com.joojoo.api.user.application.port.in.GetUserUseCase;
 import com.joojoo.api.user.domain.model.entity.User;
-import com.joojoo.api.user.domain.repository.UserRepository;
+import com.joojoo.api.util.metadata.MetadataService;
 import com.joojoo.global.exception.handleException.block.BlockNotFoundException;
-import com.joojoo.global.exception.handleException.users.UserNotFoundException;
 import com.joojoo.global.util.HangulUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,8 +35,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class BlockServiceImpl implements BlockService {
 
+    private final GetUserUseCase getUserUseCase;
+
     private final BlockRepository blockRepository;
-    private final UserRepository userRepository;
     private final BlockTreeValidator blockTreeValidator;
     private final MetadataService metadataService;
 
@@ -49,7 +49,7 @@ public class BlockServiceImpl implements BlockService {
     @Transactional
     public BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto) {
         blockTreeValidator.validateStructure(requestDto);
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        User user = getUserUseCase.getUser(userId);
 
         List<Block> allBlocks = createAndSaveBlocks(user, requestDto.getBlocks());
         metadataService.processMetadata(allBlocks, user.getId());

--- a/src/main/java/com/joojoo/api/block/application/BlockUseCaseService.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockUseCaseService.java
@@ -1,0 +1,18 @@
+package com.joojoo.api.block.application;
+
+import com.joojoo.api.block.application.port.in.DeleteBlockUseCase;
+import com.joojoo.api.block.domain.repository.BlockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BlockUseCaseService implements DeleteBlockUseCase {
+
+    private final BlockRepository blockRepository;
+
+    @Override
+    public void deleteAllBlockMappings(Long userId) {
+        blockRepository.deleteAllBlockMappings(userId);
+    }
+}

--- a/src/main/java/com/joojoo/api/block/application/port/in/DeleteBlockUseCase.java
+++ b/src/main/java/com/joojoo/api/block/application/port/in/DeleteBlockUseCase.java
@@ -1,0 +1,5 @@
+package com.joojoo.api.block.application.port.in;
+
+public interface DeleteBlockUseCase {
+    void deleteAllBlockMappings(Long userId);
+}

--- a/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
+++ b/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
@@ -35,5 +35,5 @@ public interface BlockRepository {
 
     Optional<Block> findByIdWithChildren(Long blockId);
 
-    void withdrawByUserId(Long userId);
+    void deleteAllBlockMappings(Long userId);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepository.java
@@ -10,5 +10,5 @@ public interface BlockQueryDslRepository {
 
     Map<Long, Long> getChildCounts(List<Long> rootIds);
 
-    void withdrawByUserId(Long userId);
+    void deleteAllBlockMappings(Long userId);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepositoryImpl.java
@@ -59,7 +59,7 @@ public class BlockQueryDslRepositoryImpl implements BlockQueryDslRepository {
     }
 
     @Override
-    public void withdrawByUserId(Long userId) {
+    public void deleteAllBlockMappings(Long userId) {
         queryFactory.delete(blockTag)
                 .where(blockTag.userId.eq(userId))
                 .execute();

--- a/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/rdbms/BlockRepositoryImpl.java
@@ -87,8 +87,8 @@ public class BlockRepositoryImpl implements BlockRepository {
     }
 
     @Override
-    public void withdrawByUserId(Long userId) {
-        blockQueryDslRepository.withdrawByUserId(userId);
+    public void deleteAllBlockMappings(Long userId) {
+        blockQueryDslRepository.deleteAllBlockMappings(userId);
     }
 
 

--- a/src/main/java/com/joojoo/api/tradeLog/application/TradeLogUseCaseService.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/TradeLogUseCaseService.java
@@ -1,0 +1,18 @@
+package com.joojoo.api.tradeLog.application;
+
+import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
+import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TradeLogUseCaseService implements DeleteTradeLogUseCase {
+
+    private final TradeLogRepository tradeLogRepository;
+
+    @Override
+    public void withdrawByUserId(Long userId) {
+        tradeLogRepository.withdrawByUserId(userId);
+    }
+}

--- a/src/main/java/com/joojoo/api/tradeLog/application/port/in/DeleteTradeLogUseCase.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/port/in/DeleteTradeLogUseCase.java
@@ -1,0 +1,5 @@
+package com.joojoo.api.tradeLog.application.port.in;
+
+public interface DeleteTradeLogUseCase {
+    void withdrawByUserId(Long userId);
+}

--- a/src/main/java/com/joojoo/api/user/application/UserServiceImpl.java
+++ b/src/main/java/com/joojoo/api/user/application/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.user.application;
 
 import com.joojoo.api.jwt.application.JwtTokenUseCase;
+import com.joojoo.api.user.application.port.in.GetUserUseCase;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.model.enums.DefaultProfileImage;
 import com.joojoo.api.user.domain.provider.fileService;

--- a/src/main/java/com/joojoo/api/user/application/UserUseCaseService.java
+++ b/src/main/java/com/joojoo/api/user/application/UserUseCaseService.java
@@ -1,0 +1,61 @@
+package com.joojoo.api.user.application;
+
+import com.joojoo.api.block.application.port.in.DeleteBlockUseCase;
+import com.joojoo.api.block.domain.repository.BlockRepository;
+import com.joojoo.api.jwt.application.JwtTokenUseCase;
+import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
+import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
+import com.joojoo.api.user.application.auth.withdraw.out.SocialUnlink;
+import com.joojoo.api.user.application.port.in.GetUserUseCase;
+import com.joojoo.api.user.application.port.in.WithdrawUserUseCase;
+import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.api.user.domain.repository.UserRepository;
+import com.joojoo.api.user.domain.service.auth.AppleClientSecret;
+import com.joojoo.api.user.domain.service.auth.KakaoClientSecret;
+import com.joojoo.api.util.random.GeneratorRandom;
+import com.joojoo.global.exception.handleException.users.UserNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserUseCaseService implements GetUserUseCase, WithdrawUserUseCase {
+
+    private final UserRepository userRepository;
+    private final JwtTokenUseCase jwtTokenUseCase;
+    private final DeleteBlockUseCase deleteBlockUseCase;
+    private final DeleteTradeLogUseCase deleteTradeLogUseCase;
+    private final Map<String, SocialUnlink> socialUnlink;
+
+    @Override
+    public User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    @Override
+    @Transactional
+    public void withdraw(Long userId, HttpServletRequest request) {
+        User user = this.getUser(userId);
+
+        unSocialWithdraw(user); // 소셜 계정 탈퇴
+        deleteBlockUseCase.deleteAllBlockMappings(userId); // 블럭(노트) 연관관계 정리
+        deleteTradeLogUseCase.withdrawByUserId(userId); // 템플릿 정리
+        jwtTokenUseCase.clearUserTokens(userId, request); // 토큰 정리
+        user.withdraw(); // 회원 DB 정리
+
+        // TODO : 추후에 고도화 이미지 삭제 해야 함 !!
+    }
+
+    private void unSocialWithdraw(User user) {
+        SocialUnlink strategy = socialUnlink.get(user.getProvider().name());
+        if (strategy != null) {
+            strategy.unlink(user);
+        }
+    }
+}

--- a/src/main/java/com/joojoo/api/user/application/auth/AuthSocialService.java
+++ b/src/main/java/com/joojoo/api/user/application/auth/AuthSocialService.java
@@ -2,11 +2,9 @@ package com.joojoo.api.user.application.auth;
 
 import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
 import com.joojoo.api.user.presentation.dto.response.LoginResponse;
-import jakarta.servlet.http.HttpServletRequest;
 
 public interface AuthSocialService {
     LoginResponse kakaoWebSocialLogin(String code);
     LoginResponse kakaoAppSocialLogin(AuthTokenDto authTokenDto);
     LoginResponse appleSocialLogin(String code);
-    void withdraw(Long userId, HttpServletRequest request);
 }

--- a/src/main/java/com/joojoo/api/user/application/auth/AuthSocialServiceImpl.java
+++ b/src/main/java/com/joojoo/api/user/application/auth/AuthSocialServiceImpl.java
@@ -1,9 +1,6 @@
 package com.joojoo.api.user.application.auth;
 
-import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.jwt.application.JwtTokenUseCase;
-import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
-import com.joojoo.api.user.application.auth.withdraw.out.SocialUnlink;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
 import com.joojoo.api.user.domain.service.auth.AppleClientSecret;
@@ -15,8 +12,6 @@ import com.joojoo.api.user.presentation.dto.request.kakao.AccessTokenDto;
 import com.joojoo.api.user.presentation.dto.request.kakao.KakaoUserDto;
 import com.joojoo.api.user.presentation.dto.response.LoginResponse;
 import com.joojoo.api.util.random.GeneratorRandom;
-import com.joojoo.global.exception.handleException.users.UserNotFoundException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,10 +28,7 @@ public class AuthSocialServiceImpl implements AuthSocialService {
     private final JwtTokenUseCase jwtTokenUseCase;
     private final KakaoClientSecret kakaoClientSecret;
     private final AppleClientSecret appleClientSecret;
-    private final Map<String, SocialUnlink> socialUnlink;
     private final GeneratorRandom generatorRandom;
-    private final BlockRepository blockRepository;
-    private final TradeLogRepository tradeLogRepository;
 
     @Override
     @Transactional
@@ -65,28 +57,6 @@ public class AuthSocialServiceImpl implements AuthSocialService {
 
         User user = registerOrLogin(appleUser.getProviderId(), appleTokenResponse.getRefreshToken(), appleUser.getEmail());
         return generateLoginResponse(user);
-    }
-
-    @Override
-    @Transactional
-    public void withdraw(Long userId, HttpServletRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        unSocialWithdraw(user); // 소셜 계정 탈퇴
-        blockRepository.withdrawByUserId(userId); // 블럭(노트) 연관관계 정리
-        tradeLogRepository.withdrawByUserId(userId); // 템플릿 정리
-        jwtTokenUseCase.clearUserTokens(userId, request); // 토큰 정리
-        user.withdraw(); // 회원 DB 정리
-
-        // TODO : 추후에 고도화 이미지 삭제 해야 함 !!
-    }
-
-    private void unSocialWithdraw(User user) {
-        SocialUnlink strategy = socialUnlink.get(user.getProvider().name());
-        if (strategy != null) {
-            strategy.unlink(user);
-        }
     }
 
     private LoginResponse generateLoginResponse(User user){

--- a/src/main/java/com/joojoo/api/user/application/port/in/GetUserUseCase.java
+++ b/src/main/java/com/joojoo/api/user/application/port/in/GetUserUseCase.java
@@ -1,0 +1,9 @@
+package com.joojoo.api.user.application.port.in;
+
+import com.joojoo.api.user.domain.model.entity.User;
+
+/** 회원을 조회하는 인터페이스 */
+public interface GetUserUseCase {
+    /** 회원 조회 */
+    User getUser(Long userId);
+}

--- a/src/main/java/com/joojoo/api/user/application/port/in/WithdrawUserUseCase.java
+++ b/src/main/java/com/joojoo/api/user/application/port/in/WithdrawUserUseCase.java
@@ -1,0 +1,8 @@
+package com.joojoo.api.user.application.port.in;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/** 계정을 탈퇴하는 인터페이스 */
+public interface WithdrawUserUseCase {
+    void withdraw(Long userId, HttpServletRequest request);
+}

--- a/src/main/java/com/joojoo/api/user/infrastructure/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/persistence/UserPersistenceAdapter.java
@@ -1,7 +1,8 @@
-package com.joojoo.api.user.infrastructure.rdbms;
+package com.joojoo.api.user.infrastructure.persistence;
 
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
+import com.joojoo.api.user.infrastructure.rdbms.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
-public class UserRepositoryImpl implements UserRepository {
+public class UserPersistenceAdapter implements UserRepository {
 
     private final UserJpaRepository userJpaRepository;
 

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -2,6 +2,7 @@ package com.joojoo.api.user.presentation.controller;
 
 import com.joojoo.api.user.application.UserService;
 import com.joojoo.api.user.application.auth.AuthSocialService;
+import com.joojoo.api.user.application.port.in.WithdrawUserUseCase;
 import com.joojoo.api.user.presentation.dto.request.AuthCodeDto;
 import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
 import com.joojoo.api.user.presentation.dto.request.UpdateProfileDto;
@@ -30,6 +31,8 @@ public class UserController {
 
     private final AuthSocialService authSocialService;
     private final UserService userService;
+
+    private final WithdrawUserUseCase withdrawUserUseCase;
 
     @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 전달받아 소셜 로그인을 진행합니다.")
     @ApiResponses({
@@ -80,7 +83,7 @@ public class UserController {
     })
     @PostMapping("/withdraw")
     public BaseResponse<String> withdraw(@AuthenticationPrincipal CustomUserDetails user, HttpServletRequest request) {
-        authSocialService.withdraw(user.getUserId(), request);
+        withdrawUserUseCase.withdraw(user.getUserId(), request);
         return BaseResponse.ok("회원 탈퇴가 완료되었습니다.");
     }
 


### PR DESCRIPTION
## 📌 PR 제목

- [Refactor] 계정 탈퇴 로직 DDD 및 Hexagonal Architecture 적용 리팩토링

---

## 작업 개요

계정 탈퇴(Withdraw) 로직을 기존의 단일 서비스 방식에서 **Hexagonal Architecture의 UseCase/Port 패턴** 으로 리팩토링하였습니다. 도메인 간 결합도를 낮추고, 소셜 플랫폼별 탈퇴 로직을 전략 패턴으로 분리하여 유지보수성을 높였습니다.

---

## 작업 내용

### 1. 인터페이스 분리 및 UseCase 도입 (ISP 적용)
- `GetUserUseCase`, `WithdrawUserUseCase`로 인터페이스를 세분화하여 각 클라이언트(Controller, Other Service)가 필요한 기능에만 의존하도록 개선했습니다.
- `UserUseCaseService` 구현체를 통해 애플리케이션 계층의 비즈니스 흐름을 관리합니다.

### 2. 전략 패턴을 이용한 소셜 탈퇴 로직 추상화
- `SocialUnlink` 인터페이스를 정의하고 각 플랫폼별 구현체(`AppleUnlink`, `KakaoUnlinkImpl`)를 분리했습니다.
- 신규 소셜 로그인 수단 추가 시 기존 코드 수정 없이 확장 가능한 **OCP(개방-폐쇄 원칙)** 구조를 확립했습니다.

### 3. 도메인 간 느슨한 결합 (Loose Coupling)
- `User` 서비스에서 타 도메인 데이터 삭제 시, Repository 직접 참조 대신 해당 도메인의 입구인 **UseCase(`DeleteBlockUseCase`, `DeleteTradeLogUseCase`)를 호출** 하여 도메인 간 경계를 준수했습니다.

