### PR TITLE
refactor: 로그아웃 DDD + hexagonal 로 리팩토링

### DIFF
--- a/src/main/java/com/joojoo/api/user/application/UserService.java
+++ b/src/main/java/com/joojoo/api/user/application/UserService.java
@@ -3,10 +3,8 @@ package com.joojoo.api.user.application;
 import com.joojoo.api.user.presentation.dto.request.UpdateProfileDto;
 import com.joojoo.api.user.presentation.dto.response.DefaultProfileImageResponse;
 import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
-import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserService {
-    void logout(Long userId, HttpServletRequest request);
 
     DefaultProfileImageResponse getDefaultProfileImages();
 

--- a/src/main/java/com/joojoo/api/user/application/UserServiceImpl.java
+++ b/src/main/java/com/joojoo/api/user/application/UserServiceImpl.java
@@ -1,7 +1,5 @@
 package com.joojoo.api.user.application;
 
-import com.joojoo.api.jwt.application.JwtTokenUseCase;
-import com.joojoo.api.user.application.port.in.GetUserUseCase;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.model.enums.DefaultProfileImage;
 import com.joojoo.api.user.domain.provider.fileService;
@@ -12,7 +10,6 @@ import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
 import com.joojoo.global.exception.handleException.users.UserNameDuplicatedException;
 import com.joojoo.global.exception.handleException.users.UserNameRequiredException;
 import com.joojoo.global.exception.handleException.users.UserNotFoundException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,17 +22,7 @@ import java.util.stream.Collectors;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
-    private final JwtTokenUseCase jwtTokenUseCase;
     private final fileService fileService;
-
-    @Override
-    public void logout(Long userId, HttpServletRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        // 토큰 정리
-        jwtTokenUseCase.clearUserTokens(userId, request);
-    }
 
     @Override
     public DefaultProfileImageResponse getDefaultProfileImages() {

--- a/src/main/java/com/joojoo/api/user/application/UserUseCaseService.java
+++ b/src/main/java/com/joojoo/api/user/application/UserUseCaseService.java
@@ -7,6 +7,7 @@ import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import com.joojoo.api.user.application.auth.withdraw.out.SocialUnlink;
 import com.joojoo.api.user.application.port.in.GetUserUseCase;
+import com.joojoo.api.user.application.port.in.LogoutUseCase;
 import com.joojoo.api.user.application.port.in.WithdrawUserUseCase;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
@@ -24,7 +25,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class UserUseCaseService implements GetUserUseCase, WithdrawUserUseCase {
+public class UserUseCaseService implements GetUserUseCase, WithdrawUserUseCase, LogoutUseCase {
 
     private final UserRepository userRepository;
     private final JwtTokenUseCase jwtTokenUseCase;
@@ -57,5 +58,11 @@ public class UserUseCaseService implements GetUserUseCase, WithdrawUserUseCase {
         if (strategy != null) {
             strategy.unlink(user);
         }
+    }
+
+    @Override
+    public void logout(Long userId, HttpServletRequest request) {
+        User user = this.getUser(userId);
+        jwtTokenUseCase.clearUserTokens(userId, request);
     }
 }

--- a/src/main/java/com/joojoo/api/user/application/port/in/LogoutUseCase.java
+++ b/src/main/java/com/joojoo/api/user/application/port/in/LogoutUseCase.java
@@ -1,0 +1,7 @@
+package com.joojoo.api.user.application.port.in;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface LogoutUseCase {
+    void logout(Long userId, HttpServletRequest request);
+}

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -2,6 +2,7 @@ package com.joojoo.api.user.presentation.controller;
 
 import com.joojoo.api.user.application.UserService;
 import com.joojoo.api.user.application.auth.AuthSocialService;
+import com.joojoo.api.user.application.port.in.LogoutUseCase;
 import com.joojoo.api.user.application.port.in.WithdrawUserUseCase;
 import com.joojoo.api.user.presentation.dto.request.AuthCodeDto;
 import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
@@ -33,6 +34,7 @@ public class UserController {
     private final UserService userService;
 
     private final WithdrawUserUseCase withdrawUserUseCase;
+    private final LogoutUseCase logoutUseCase;
 
     @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 전달받아 소셜 로그인을 진행합니다.")
     @ApiResponses({
@@ -98,7 +100,7 @@ public class UserController {
     })
     @PostMapping("/logout")
     public BaseResponse<String> logout(@AuthenticationPrincipal CustomUserDetails user, HttpServletRequest request) {
-        userService.logout(user.getUserId(), request);
+        logoutUseCase.logout(user.getUserId(), request);
         return BaseResponse.ok("로그아웃이 완료되었습니다.");
     }
 


### PR DESCRIPTION
## 📌 PR 제목

- [Refactor] 로그아웃 로직 ISP 적용 및 Hexagonal 구조 리팩토링

---

## 작업 개요

기존 `UserService`에 비대하게 모여 있던 기능을 헥사고날 아키텍처의 **In-Port(UseCase)** 개념을 도입하여 분리하였습니다. 특히 로그아웃 기능을 별도의 인터페이스로 추출하여 인터페이스 분리 원칙(ISP)을 준수하도록 수정했습니다.

---

## 작업 내용

### 1. LogoutUseCase 인터페이스 분리 (ISP 적용)
- 유저 정보 관리와 성격이 다른 인증 관련 행위인 '로그아웃'을 `LogoutUseCase` 인터페이스로 독립시켰습니다.
- 이를 통해 컨트롤러 및 타 서비스에서 로그아웃 기능만 필요할 경우, 전체 유저 관리 기능에 의존하지 않고 전용 인터페이스만 주입받아 사용할 수 있게 되었습니다.

### 2. UserUseCaseService 다중 구현 적용
- 기존의 로그아웃 로직은 유지하되, `UserUseCaseService`가 `LogoutUseCase`를 추가로 구현(implements)하도록 변경하였습니다.
- 내부 비즈니스 로직의 응집도는 유지하면서 외부로 노출되는 인터페이스 명세를 명확히 분리했습니다.

### 3. 클라이언트(Controller) 의존성 정합성 수정
- `UserController`에서 로그아웃 요청 시 기존의 거대 서비스 인터페이스 대신 `LogoutUseCase`를 주입받아 사용하도록 수정하여 결합도를 낮췄습니다.
