### PR TITLE
Refactor/block save ddd hexagonal

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockService.java
@@ -1,17 +1,13 @@
 package com.joojoo.api.block.application;
 
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
-import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
-import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.block.presentation.dto.response.mainView.BlockMainViewResponse;
 
 import java.time.LocalDate;
 
 public interface BlockService {
-    BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto);
-
     BlockDetailResponseDto getBlockDetail(Long blockId);
 
     BlockMainViewResponse getBlockMainView(Long userId, LocalDate lastDate);

--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -5,10 +5,7 @@ import com.joojoo.api.block.application.validate.blockerTree.BlockTreeValidator;
 import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.domain.repository.BlockRepository;
-import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
-import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
-import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.block.presentation.dto.response.mainView.BlockMainViewResponse;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
@@ -17,7 +14,6 @@ import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import com.joojoo.api.tag.domain.model.entity.Tag;
 import com.joojoo.api.user.application.port.in.GetUserUseCase;
-import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.util.metadata.MetadataService;
 import com.joojoo.global.exception.handleException.block.BlockNotFoundException;
 import com.joojoo.global.util.HangulUtils;
@@ -44,17 +40,6 @@ public class BlockServiceImpl implements BlockService {
     private final BlockDtoAssembler blockDtoAssembler;
     private final BlockTagRepository blockTagRepository;
     private final BlockTickerRepository blockTickerRepository;
-
-    @Override
-    @Transactional
-    public BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto) {
-        blockTreeValidator.validateStructure(requestDto);
-        User user = getUserUseCase.getUser(userId);
-
-        List<Block> allBlocks = createAndSaveBlocks(user, requestDto.getBlocks());
-        metadataService.processMetadata(allBlocks, user.getId());
-        return blockDtoAssembler.assembleReconstructBlockTree(allBlocks);
-    }
 
     @Override
     @Transactional(readOnly = true)
@@ -186,24 +171,6 @@ public class BlockServiceImpl implements BlockService {
             blockRepository.updateSequenceWithParent(targetBlock.getUser(), targetBlock.getParent(), targetBlock.getSequence(), offset);
         } else {
             blockRepository.updateSequenceRoot(targetBlock.getUser(), targetBlock.getSequence(), offset);
-        }
-    }
-
-    /** 리스트에 블럭을 담아 한번에 저장하는 메서드 */
-    private List<Block> createAndSaveBlocks(User user, List<BlockRequestDto> dtos) {
-        List<Block> allBlocks = new ArrayList<>();
-        blocksRecursive(user, null, dtos, allBlocks);
-        return blockRepository.saveAll(allBlocks); // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중
-    }
-
-    /** RequestDto를 순회하며 JPA 엔티티(Block)를 생성하고, allBlocks에 수집하는 메서드 */
-    private void blocksRecursive(User user, Block parentBlock, List<BlockRequestDto> blockDtos, List<Block> allBlocks) {
-        if (blockDtos == null || blockDtos.isEmpty()) { return; }
-
-        for (BlockRequestDto dto : blockDtos) {
-            Block block = Block.createBlockBuild(user, parentBlock, dto);
-            allBlocks.add(block);
-            blocksRecursive(user, block, dto.getChildren(), allBlocks); // 자식 재귀 호출
         }
     }
 

--- a/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssembler.java
+++ b/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssembler.java
@@ -1,7 +1,6 @@
 package com.joojoo.api.block.application.detail;
 
 import com.joojoo.api.block.domain.model.entity.Block;
-import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
@@ -16,8 +15,4 @@ public interface BlockDtoAssembler {
     // 메인 페이지용
     List<BlockDetailResponseDto> assembleMainList(List<Block> blocks, List<BlockTag> tags, List<BlockTicker> tickers, Map<Long, Long> childCounts);
 
-    // 리스트형식에서 응답 형식인 트리구조로 변환
-    BlockResponse assembleReconstructBlockTree(List<Block> allBlocks);
-
-    List<Long> toIds(List<Block> blockIds);
 }

--- a/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssemblerImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/detail/BlockDtoAssemblerImpl.java
@@ -1,8 +1,6 @@
 package com.joojoo.api.block.application.detail;
 
 import com.joojoo.api.block.domain.model.entity.Block;
-import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
-import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponseDto;
 import com.joojoo.api.block.presentation.dto.response.detail.BlockDetailResponseDto;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
@@ -56,49 +54,6 @@ public class BlockDtoAssemblerImpl implements BlockDtoAssembler {
                         childCounts.getOrDefault(block.getId(), 0L)
                 ))
                 .toList();
-    }
-
-    @Override
-    public BlockResponse assembleReconstructBlockTree(List<Block> allBlocks) {
-        Map<Long, BlockResponseDto> dtoMap = getBlockResponseDtoMap(allBlocks);
-        connectNodes(allBlocks, dtoMap);
-        return BlockResponse.of(getRootBlocks(allBlocks, dtoMap));
-    }
-
-    @Override
-    public List<Long> toIds(List<Block> blockIds) {
-        return blockIds.stream()
-                .map(Block::getId)
-                .collect(Collectors.toList());
-    }
-
-    /** Root 블럭만 추출해 리스트로 변환 */
-    private static List<BlockResponseDto> getRootBlocks(List<Block> allBlocks, Map<Long, BlockResponseDto> dtoMap) {
-        return allBlocks.stream()
-                .filter(b -> b.getParent() == null)
-                .map(b -> dtoMap.get(b.getId()))
-                .toList();
-    }
-
-    /** BlockResponseDto 전용 맵 생성 */
-    private static Map<Long, BlockResponseDto> getBlockResponseDtoMap(List<Block> allBlocks) {
-        return allBlocks.stream()
-                .map(block -> BlockResponseDto.of(block, new ArrayList<>()))
-                .collect(Collectors.toMap(BlockResponseDto::getBlockId, dto -> dto));
-    }
-
-    /** 부모-자식 관계 연결 담당하는 전용 메서드 */
-    private void connectNodes(List<Block> allBlocks, Map<Long, BlockResponseDto> dtoMap) {
-        for (Block block : allBlocks) {
-            if (block.getParent() != null) { // 부모 블럭이 아니면
-                // 부모 블럭을 찾는다.
-                BlockResponseDto parentDto = dtoMap.get(block.getParent().getId());
-                if (parentDto != null) { // 부모 블럭이 있다면
-                    // 부모블럭에 현재 자식 블럭을 추가한다.
-                    parentDto.getChildren().add(dtoMap.get(block.getId()));
-                }
-            }
-        }
     }
 
     /** Tag 전용 맵 생성 */

--- a/src/main/java/com/joojoo/api/block/application/port/in/CreateBlockUseCase.java
+++ b/src/main/java/com/joojoo/api/block/application/port/in/CreateBlockUseCase.java
@@ -1,0 +1,9 @@
+package com.joojoo.api.block.application.port.in;
+
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+
+public interface CreateBlockUseCase {
+    /** 블럭 생성 */
+    BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto);
+}

--- a/src/main/java/com/joojoo/api/block/application/port/out/BlockPort.java
+++ b/src/main/java/com/joojoo/api/block/application/port/out/BlockPort.java
@@ -1,0 +1,10 @@
+package com.joojoo.api.block.application.port.out;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+
+import java.util.List;
+
+/** CRUD만 사용 */
+public interface BlockPort {
+    void saveAll(List<Block> allBlocks);
+}

--- a/src/main/java/com/joojoo/api/block/application/service/command/CreateBlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/service/command/CreateBlockService.java
@@ -1,8 +1,8 @@
 package com.joojoo.api.block.application.service.command;
 
 import com.joojoo.api.block.application.port.in.CreateBlockUseCase;
+import com.joojoo.api.block.application.port.out.BlockPort;
 import com.joojoo.api.block.domain.model.entity.Block;
-import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.block.domain.service.BlockDomainService;
 import com.joojoo.api.block.domain.service.assembler.BlockTreeAssembler;
 import com.joojoo.api.block.domain.service.validation.BlockValidator;
@@ -22,7 +22,7 @@ import java.util.List;
 @Transactional
 public class CreateBlockService implements CreateBlockUseCase {
 
-    private final BlockRepository blockRepository;
+    private final BlockPort blockPort;
     private final GetUserUseCase getUserUseCase;
     private final BlockDomainService blockDomainService;
     private final BlockValidator blockValidator;
@@ -35,7 +35,7 @@ public class CreateBlockService implements CreateBlockUseCase {
         User user = getUserUseCase.getUser(userId);
 
         List<Block> allBlocks = blockDomainService.createAndSaveBlocks(user, requestDto.getBlocks());
-        blockRepository.saveAll(allBlocks); // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중
+        blockPort.saveAll(allBlocks); // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중
 
         metadataUseCase.processMetadata(allBlocks, user.getId());
         return blockTreeAssembler.assembleReconstructBlockTree(allBlocks);

--- a/src/main/java/com/joojoo/api/block/application/service/command/CreateBlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/service/command/CreateBlockService.java
@@ -1,10 +1,10 @@
 package com.joojoo.api.block.application.service.command;
 
-import com.joojoo.api.block.application.detail.BlockDtoAssembler;
 import com.joojoo.api.block.application.port.in.CreateBlockUseCase;
 import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.block.domain.service.BlockDomainService;
+import com.joojoo.api.block.domain.service.assembler.BlockTreeAssembler;
 import com.joojoo.api.block.domain.service.validation.BlockValidator;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
@@ -26,9 +26,8 @@ public class CreateBlockService implements CreateBlockUseCase {
     private final GetUserUseCase getUserUseCase;
     private final BlockDomainService blockDomainService;
     private final BlockValidator blockValidator;
-
+    private final BlockTreeAssembler blockTreeAssembler;
     private final MetadataUseCase metadataUseCase;
-    private final BlockDtoAssembler blockDtoAssembler;
 
     @Override
     public BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto) {
@@ -39,8 +38,7 @@ public class CreateBlockService implements CreateBlockUseCase {
         blockRepository.saveAll(allBlocks); // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중
 
         metadataUseCase.processMetadata(allBlocks, user.getId());
-        return blockDtoAssembler.assembleReconstructBlockTree(allBlocks);
+        return blockTreeAssembler.assembleReconstructBlockTree(allBlocks);
     }
-
 
 }

--- a/src/main/java/com/joojoo/api/block/application/service/command/CreateBlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/service/command/CreateBlockService.java
@@ -1,0 +1,46 @@
+package com.joojoo.api.block.application.service.command;
+
+import com.joojoo.api.block.application.detail.BlockDtoAssembler;
+import com.joojoo.api.block.application.port.in.CreateBlockUseCase;
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.domain.repository.BlockRepository;
+import com.joojoo.api.block.domain.service.BlockDomainService;
+import com.joojoo.api.block.domain.service.validation.BlockValidator;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+import com.joojoo.api.metadata.application.port.in.MetadataUseCase;
+import com.joojoo.api.user.application.port.in.GetUserUseCase;
+import com.joojoo.api.user.domain.model.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateBlockService implements CreateBlockUseCase {
+
+    private final BlockRepository blockRepository;
+    private final GetUserUseCase getUserUseCase;
+    private final BlockDomainService blockDomainService;
+    private final BlockValidator blockValidator;
+
+    private final MetadataUseCase metadataUseCase;
+    private final BlockDtoAssembler blockDtoAssembler;
+
+    @Override
+    public BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto) {
+        blockValidator.validateStructure(requestDto);
+        User user = getUserUseCase.getUser(userId);
+
+        List<Block> allBlocks = blockDomainService.createAndSaveBlocks(user, requestDto.getBlocks());
+        blockRepository.saveAll(allBlocks); // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중
+
+        metadataUseCase.processMetadata(allBlocks, user.getId());
+        return blockDtoAssembler.assembleReconstructBlockTree(allBlocks);
+    }
+
+
+}

--- a/src/main/java/com/joojoo/api/block/domain/service/BlockDomainService.java
+++ b/src/main/java/com/joojoo/api/block/domain/service/BlockDomainService.java
@@ -1,0 +1,33 @@
+package com.joojoo.api.block.domain.service;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
+import com.joojoo.api.user.domain.model.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BlockDomainService {
+
+    /** 리스트에 블럭을 담아 한번에 저장하는 메서드 */
+    public List<Block> createAndSaveBlocks(User user, List<BlockRequestDto> dtos) {
+        List<Block> allBlocks = new ArrayList<>();
+        blocksRecursive(user, null, dtos, allBlocks);
+        return allBlocks;
+    }
+
+    /** RequestDto를 순회하며 JPA 엔티티(Block)를 생성하고, allBlocks에 수집하는 메서드 */
+    public void blocksRecursive(User user, Block parentBlock, List<BlockRequestDto> blockDtos, List<Block> allBlocks) {
+        if (blockDtos == null || blockDtos.isEmpty()) { return; }
+
+        for (BlockRequestDto dto : blockDtos) {
+            Block block = Block.createBlockBuild(user, parentBlock, dto);
+            allBlocks.add(block);
+            blocksRecursive(user, block, dto.getChildren(), allBlocks); // 자식 재귀 호출
+        }
+    }
+}

--- a/src/main/java/com/joojoo/api/block/domain/service/assembler/BlockTreeAssembler.java
+++ b/src/main/java/com/joojoo/api/block/domain/service/assembler/BlockTreeAssembler.java
@@ -1,0 +1,51 @@
+package com.joojoo.api.block.domain.service.assembler;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
+import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponseDto;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class BlockTreeAssembler {
+
+    /** 리스트형식에서 응답 형식인 트리구조로 변환 */
+    public BlockResponse assembleReconstructBlockTree(List<Block> allBlocks) {
+        Map<Long, BlockResponseDto> dtoMap = getBlockResponseDtoMap(allBlocks);
+        connectNodes(allBlocks, dtoMap);
+        return BlockResponse.of(getRootBlocks(allBlocks, dtoMap));
+    }
+
+    /** BlockResponseDto 전용 맵 생성 */
+    private static Map<Long, BlockResponseDto> getBlockResponseDtoMap(List<Block> allBlocks) {
+        return allBlocks.stream()
+                .map(block -> BlockResponseDto.of(block, new ArrayList<>()))
+                .collect(Collectors.toMap(BlockResponseDto::getBlockId, dto -> dto));
+    }
+
+    /** 부모-자식 관계 연결 담당하는 전용 메서드 */
+    private void connectNodes(List<Block> allBlocks, Map<Long, BlockResponseDto> dtoMap) {
+        for (Block block : allBlocks) {
+            if (block.getParent() != null) { // 부모 블럭이 아니면
+                // 부모 블럭을 찾는다.
+                BlockResponseDto parentDto = dtoMap.get(block.getParent().getId());
+                if (parentDto != null) { // 부모 블럭이 있다면
+                    // 부모블럭에 현재 자식 블럭을 추가한다.
+                    parentDto.getChildren().add(dtoMap.get(block.getId()));
+                }
+            }
+        }
+    }
+
+    /** Root 블럭만 추출해 리스트로 변환 */
+    private static List<BlockResponseDto> getRootBlocks(List<Block> allBlocks, Map<Long, BlockResponseDto> dtoMap) {
+        return allBlocks.stream()
+                .filter(b -> b.getParent() == null)
+                .map(b -> dtoMap.get(b.getId()))
+                .toList();
+    }
+}

--- a/src/main/java/com/joojoo/api/block/domain/service/validation/BlockValidator.java
+++ b/src/main/java/com/joojoo/api/block/domain/service/validation/BlockValidator.java
@@ -1,0 +1,44 @@
+package com.joojoo.api.block.domain.service.validation;
+
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.global.exception.enums.ErrorCode;
+import com.joojoo.global.exception.handleException.block.InvalidBlockStructureException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BlockValidator {
+
+    public static final int MAX_DEPTH = 2;
+
+    /** 트리 구조 검증 */
+    public void validateStructure(BlockSaveRequestDto requestDto) {
+        if (requestDto.getBlocks() == null || requestDto.getBlocks().size() != 1) {
+            throw new InvalidBlockStructureException(ErrorCode.INVALID_ROOT_BLOCK_COUNT);
+        }
+
+        validateDepth(requestDto.getBlocks().get(0), 0);
+    }
+
+    private void validateDepth(BlockRequestDto block, int currentDepth) {
+        if (currentDepth == MAX_DEPTH) {
+            if (block.getChildren() != null && !block.getChildren().isEmpty()) {
+                throw new InvalidBlockStructureException(ErrorCode.MAX_BLOCK_DEPTH_EXCEEDED);
+            }
+            return;
+        }
+
+        if (currentDepth > MAX_DEPTH) {
+            throw new InvalidBlockStructureException(ErrorCode.MAX_BLOCK_DEPTH_EXCEEDED);
+        }
+
+        if (block.getChildren() != null) {
+            for (BlockRequestDto child : block.getChildren()) {
+                validateDepth(child, currentDepth + 1);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/joojoo/api/block/infrastructure/persistence/BlockPortAdapter.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/persistence/BlockPortAdapter.java
@@ -1,0 +1,22 @@
+package com.joojoo.api.block.infrastructure.persistence;
+
+import com.joojoo.api.block.application.port.out.BlockPort;
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.infrastructure.rdbms.BlockJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BlockPortAdapter implements BlockPort {
+
+    private final BlockJpaRepository blockJpaRepository;
+
+    @Override
+    public void saveAll(List<Block> allBlocks) {
+        blockJpaRepository.saveAll(allBlocks);
+    }
+
+}

--- a/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
+++ b/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.block.presentation.controller;
 
 import com.joojoo.api.block.application.BlockService;
+import com.joojoo.api.block.application.port.in.CreateBlockUseCase;
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
@@ -31,6 +32,8 @@ public class BlockController {
 
     private final BlockService blockService;
 
+    private final CreateBlockUseCase createBlockUseCase;
+
     @Operation(summary = "블럭(노트) 생성 API", description = "사용자가 작성한 블럭(노트) 트리 구조를 받아 저장합니다.")
     @ApiResponses({
             @ApiResponse(
@@ -49,7 +52,7 @@ public class BlockController {
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody BlockSaveRequestDto requestDto
     ) {
-        return BaseResponse.ok(blockService.saveBlockTree(user.getUserId(), requestDto));
+        return BaseResponse.ok(createBlockUseCase.saveBlockTree(user.getUserId(), requestDto));
     }
 
     @Operation(summary = "블럭(노트) 상세 페이지", description = "메인 페이지에서 더보기 버튼 누르면 자식, 자손 블럭까지 응답 합니다.")

--- a/src/main/java/com/joojoo/api/metadata/application/port/in/MetadataUseCase.java
+++ b/src/main/java/com/joojoo/api/metadata/application/port/in/MetadataUseCase.java
@@ -1,0 +1,9 @@
+package com.joojoo.api.metadata.application.port.in;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+
+import java.util.List;
+
+public interface MetadataUseCase {
+    void processMetadata(List<Block> allBlocks, Long userId);
+}

--- a/src/main/java/com/joojoo/api/metadata/application/port/out/MetadataPort.java
+++ b/src/main/java/com/joojoo/api/metadata/application/port/out/MetadataPort.java
@@ -1,0 +1,17 @@
+package com.joojoo.api.metadata.application.port.out;
+
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.tag.domain.model.entity.Tag;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MetadataPort {
+
+    /** 티커, 태그 리스트 일괄 저장 */
+    void saveTickersAndTags(List<BlockTicker> tickers, List<BlockTag> tags);
+
+    /** 회원이 사용한 태그를 Redis에 저장 */
+    void syncUserTagsToRedis(Long userId, Map<String, Tag> tagMap);
+}

--- a/src/main/java/com/joojoo/api/metadata/application/service/MetadataUseCaseService.java
+++ b/src/main/java/com/joojoo/api/metadata/application/service/MetadataUseCaseService.java
@@ -1,0 +1,60 @@
+package com.joojoo.api.metadata.application.service;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.request.metadata.MatchedMetadataDto;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.metadata.application.port.in.MetadataUseCase;
+import com.joojoo.api.metadata.application.port.out.MetadataPort;
+import com.joojoo.api.metadata.domain.service.MetadataAnalyzer;
+import com.joojoo.api.tag.application.in.TagInService;
+import com.joojoo.api.ticker.application.in.TickerInService;
+import com.joojoo.api.util.metadata.MetadataContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class MetadataUseCaseService implements MetadataUseCase {
+
+    private final MetadataAnalyzer metadataAnalyzer;
+    private final MetadataPort metadataPort;
+
+    private final TagInService tagInService;
+    private final TickerInService tickerInService;
+
+    @Override
+    @Transactional
+    public void processMetadata(List<Block> blocks, Long userId) {
+        if (blocks == null || blocks.isEmpty()) return;
+
+        MetadataContext context = new MetadataContext();
+        Map<Block, List<MatchedMetadataDto>> analysisMap = new HashMap<>();
+
+        // 티커, 태그 이름 추출 및 수집
+        for (Block block : blocks) {
+            analysisMap.put(block, metadataAnalyzer.scan(block.getContent(), context));
+        }
+
+        // 마스터 데이터(Ticker, Tag) 일괄 로드
+        context.loadEntities(tickerInService, tagInService);
+
+        // 도메인 엔티티 생성
+        List<BlockTicker> bTickers = metadataAnalyzer.createBlockTickers(analysisMap, context, userId);
+        List<BlockTag> bTags = metadataAnalyzer.createBlockTags(analysisMap, context, userId);
+        
+        // 저장 및 동기화
+        metadataPort.saveTickersAndTags(bTickers, bTags);
+
+        // Redis 저장
+        if (!context.getTagNames().isEmpty()) {
+            metadataPort.syncUserTagsToRedis(userId, context.getTagMap());
+        }
+    }
+
+}

--- a/src/main/java/com/joojoo/api/metadata/domain/service/MetadataAnalyzer.java
+++ b/src/main/java/com/joojoo/api/metadata/domain/service/MetadataAnalyzer.java
@@ -1,0 +1,89 @@
+package com.joojoo.api.metadata.domain.service;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.request.metadata.MatchedMetadataDto;
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.tag.domain.model.entity.Tag;
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import com.joojoo.api.util.metadata.MetadataContext;
+import com.joojoo.global.common.enums.TagSourceType;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class MetadataAnalyzer { /** 정규식으로 이름들을 추출하고 반환하는 "순수 로직" */
+
+    private static final Pattern COMBINED_PATTERN = Pattern.compile("\\$([a-zA-Z0-9가-힣.-]+)|#([^\\s#]+)");
+
+    /** 텍스트에서 메타데이터 추출 및 컨텍스트에 이름 수집 */
+    public List<MatchedMetadataDto> scan(String content, MetadataContext context) {
+        if (content == null || content.isEmpty()) return Collections.emptyList();
+
+        List<MatchedMetadataDto> matches = new ArrayList<>();
+        Matcher matcher = COMBINED_PATTERN.matcher(content);
+
+        while (matcher.find()) {
+            String tickerName = matcher.group(1);
+            String tagName = matcher.group(2);
+
+            if (tickerName != null) {
+                context.addTicker(tickerName);
+                matches.add(new MatchedMetadataDto(tickerName, matcher.start(), true));
+            } else if (tagName != null) {
+                context.addTag(tagName);
+                matches.add(new MatchedMetadataDto(tagName, matcher.start(), false));
+            }
+        }
+        return matches;
+    }
+
+    /** 분석된 결과를 바탕으로 BlockTicker 엔티티 리스트를 생성 */
+    public List<BlockTicker> createBlockTickers(
+            Map<Block, List<MatchedMetadataDto>> analysisMap,
+            MetadataContext context,
+            Long userId
+    ) {
+        List<BlockTicker> tickers = new ArrayList<>();
+        analysisMap.forEach((block, matches) -> {
+            int tSeq = 0;
+            for (MatchedMetadataDto match : matches) {
+                if (match.isTicker()) {
+                    Ticker ticker = context.getTicker(match.name());
+                    if (ticker != null) {
+                        tickers.add(BlockTicker.create(block, ticker, userId, match.start(), tSeq++, TagSourceType.BLOCK_CONTENT));
+                    }
+                }
+            }
+        });
+        return tickers;
+    }
+
+    /** 분석된 결과를 바탕으로 BlockTag 엔티티 리스트를 생성 */
+    public List<BlockTag> createBlockTags(
+            Map<Block, List<MatchedMetadataDto>> analysisMap,
+            MetadataContext context,
+            Long userId
+    ) {
+        List<BlockTag> tags = new ArrayList<>();
+        analysisMap.forEach((block, matches) -> {
+            int tagSeq = 0;
+            for (MatchedMetadataDto match : matches) {
+                if (!match.isTicker()) {
+                    Tag tag = context.getTag(match.name());
+                    if (tag != null) {
+                        tags.add(BlockTag.create(block, tag, userId, match.start(), tagSeq++, TagSourceType.BLOCK_CONTENT));
+                    }
+                }
+            }
+        });
+        return tags;
+    }
+
+}

--- a/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
+++ b/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
@@ -1,0 +1,46 @@
+package com.joojoo.api.metadata.infrastructure.persistence;
+
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
+import com.joojoo.api.metadata.application.port.out.MetadataPort;
+import com.joojoo.api.tag.domain.model.entity.Tag;
+import com.joojoo.global.util.HangulUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class MetadataPersistenceAdapter implements MetadataPort { // User 도메인에 있는 어뎁터도 수정해야 함
+
+    private final BlockTickerRepository blockTickerRepository;
+    private final BlockTagRepository blockTagRepository;
+
+    @Override
+    public void saveTickersAndTags(List<BlockTicker> tickers, List<BlockTag> tags) {
+        if (!tickers.isEmpty()) blockTickerRepository.saveAll(tickers);
+        if (!tags.isEmpty()) blockTagRepository.saveAll(tags);
+    }
+
+    @Override
+    public void syncUserTagsToRedis(Long userId, Map<String, Tag> tagMap) {
+        Set<String> lexEntries = new HashSet<>();
+        Set<Long> tagIds = new HashSet<>();
+
+        tagMap.forEach((name, tag) -> {
+            Long tagId = tag.getId();
+            lexEntries.add(userId + ":" + HangulUtils.splitToJaso(name) + "*" + name + "*" + tagId);
+            lexEntries.add(userId + ":" + HangulUtils.getChosung(name) + "*" + name + "*" + tagId);
+            tagIds.add(tagId);
+        });
+
+        blockTagRepository.addTagsToRedis(userId, lexEntries, tagIds);
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] Block 생성 API 리팩토링 및 메타데이터 로직 관심사 분리

---

## 작업 개요

Block 생성 로직의 응집도를 높이고 확장성을 확보하기 위해 DDD 및 헥사고날 아키텍처를 적용하여 리팩토링을 진행했습니다. 특히 비대해진 서비스 로직을 도메인 서비스와 어셈블러로 분리하여 각 객체의 책임을 명확히 했습니다.

---

## 작업 내용

- 헥사고날 아키텍처 적용 및 포트 분리
  - BlockPort 인터페이스 도입
- 도메인 서비스 및 관심사 분리
  -  기존에 존재하던 `BlockTreeAssembler` "리스트의 트리 구조 재구성" 로직을 전담하는 객체를 생성하여 분리했습니다.
  - 블록 생성의 주 흐름과 부가 흐름(메타데이터 스캔/저장)을 분리하여 각 도메인의 경계를 명확히 했습니다.
  - 엔티티 간의 관계 설정 및 조립 로직을 도메인 레이어(domain.service)로 이동시켜 Application Service는 전체적인 흐름 제어(Orchestration)에만 집중하도록 개선했습니다.
---
