### PR TITLE
Refactor/block update ddd hexagonal

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/BlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockService.java
@@ -1,11 +1,8 @@
 package com.joojoo.api.block.application;
 
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
-import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
 
 public interface BlockService {
 
     void deleteBlock(Long userId, Long blockId, DeleteMode mode);
-
-    void updateBlock(Long userId, Long blockId, BlockUpdateDto blockUpdateDto);
 }

--- a/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/BlockServiceImpl.java
@@ -4,7 +4,6 @@ import com.joojoo.api.block.application.validate.blockerTree.BlockTreeValidator;
 import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.domain.repository.BlockRepository;
-import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
 import com.joojoo.api.tag.domain.model.entity.Tag;
@@ -56,17 +55,6 @@ public class BlockServiceImpl implements BlockService {
         if (!tagsToRemove.isEmpty()) {
             processRedisTagRemoval(userId, tagsToRemove);
         }
-    }
-
-    @Override
-    @Transactional
-    public void updateBlock(Long userId, Long blockId, BlockUpdateDto blockUpdateDto) {
-        Block targetBlock = blockRepository.findByIdWithChildren(blockId)
-                .orElseThrow(BlockNotFoundException::new);
-        blockTreeValidator.validateOwner(targetBlock, userId);
-
-        targetBlock.updateContent(blockUpdateDto.getContent());
-        metadataService.processMetadata(targetBlock, userId);
     }
 
     /** Redis에 있는 태그 -1 또는 삭제 */

--- a/src/main/java/com/joojoo/api/block/application/port/in/UpdateBlockUseCase.java
+++ b/src/main/java/com/joojoo/api/block/application/port/in/UpdateBlockUseCase.java
@@ -1,0 +1,7 @@
+package com.joojoo.api.block.application.port.in;
+
+import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
+
+public interface UpdateBlockUseCase {
+    void updateBlock(Long userId, Long blockId, BlockUpdateDto blockUpdateDto);
+}

--- a/src/main/java/com/joojoo/api/block/application/service/command/UpdateBlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/service/command/UpdateBlockService.java
@@ -1,0 +1,30 @@
+package com.joojoo.api.block.application.service.command;
+
+import com.joojoo.api.block.application.port.in.UpdateBlockUseCase;
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.domain.repository.BlockRepository;
+import com.joojoo.api.block.domain.service.validation.BlockValidator;
+import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
+import com.joojoo.api.metadata.application.port.in.MetadataUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateBlockService implements UpdateBlockUseCase {
+
+    private final BlockRepository blockRepository;
+    private final BlockValidator blockValidator;
+    private final MetadataUseCase metadataUseCase;
+
+    @Override
+    @Transactional
+    public void updateBlock(Long userId, Long blockId, BlockUpdateDto blockUpdateDto) {
+        Block targetBlock = blockRepository.getBlockById(blockId);
+        blockValidator.validateOwner(targetBlock, userId);
+
+        targetBlock.updateContent(blockUpdateDto.getContent());
+        metadataUseCase.processMetadata(targetBlock, userId);
+    }
+}

--- a/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidator.java
+++ b/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidator.java
@@ -1,13 +1,10 @@
 package com.joojoo.api.block.application.validate.blockerTree;
 
 import com.joojoo.api.block.domain.model.entity.Block;
-import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 
 import java.time.LocalDate;
 
 public interface BlockTreeValidator {
-    /** 트리 구조 검증 */
-    void validateStructure(BlockSaveRequestDto requestDto);
 
     /** 날짜가 없거나, 미래 날짜이면 오늘 날짜로 변경 */
     LocalDate validateAndGetTargetDate(LocalDate lastDate);

--- a/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidatorImpl.java
+++ b/src/main/java/com/joojoo/api/block/application/validate/blockerTree/BlockTreeValidatorImpl.java
@@ -17,18 +17,7 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class BlockTreeValidatorImpl implements BlockTreeValidator {
 
-    private final BlockRepository blockRepository;
     public static final int MAX_DEPTH = 2;
-
-
-    @Override
-    public void validateStructure(BlockSaveRequestDto requestDto) {
-        if (requestDto.getBlocks() == null || requestDto.getBlocks().size() != 1) {
-            throw new InvalidBlockStructureException(ErrorCode.INVALID_ROOT_BLOCK_COUNT);
-        }
-
-        validateDepth(requestDto.getBlocks().get(0), 0);
-    }
 
     @Override /** 날짜가 없거나, 미래 날짜이면 오늘 날짜로 변경 */
     public LocalDate validateAndGetTargetDate(LocalDate lastDate) {
@@ -61,22 +50,4 @@ public class BlockTreeValidatorImpl implements BlockTreeValidator {
         }
     }
 
-    private void validateDepth(BlockRequestDto block, int currentDepth) {
-        if (currentDepth == MAX_DEPTH) {
-            if (block.getChildren() != null && !block.getChildren().isEmpty()) {
-                throw new InvalidBlockStructureException(ErrorCode.MAX_BLOCK_DEPTH_EXCEEDED);
-            }
-            return;
-        }
-
-        if (currentDepth > MAX_DEPTH) {
-            throw new InvalidBlockStructureException(ErrorCode.MAX_BLOCK_DEPTH_EXCEEDED);
-        }
-
-        if (block.getChildren() != null) {
-            for (BlockRequestDto child : block.getChildren()) {
-                validateDepth(child, currentDepth + 1);
-            }
-        }
-    }
 }

--- a/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
+++ b/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
@@ -22,7 +22,11 @@ public interface BlockRepository {
 
     LocalDate findNextAvailableDate(Long userId, LocalDate oldestDateInResult);
 
+    /** 블럭을 석택적으로 조회할 때 */
     Optional<Block> findById(Long blockId);
+
+    /** 블럭이 있을 시, 없으면 BlockNotFoundException 예외 */
+    Block getBlockById(Long blockId);
 
     void delete(Block targetBlock);
 

--- a/src/main/java/com/joojoo/api/block/domain/service/validation/BlockValidator.java
+++ b/src/main/java/com/joojoo/api/block/domain/service/validation/BlockValidator.java
@@ -1,8 +1,10 @@
 package com.joojoo.api.block.domain.service.validation;
 
+import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.global.exception.enums.ErrorCode;
+import com.joojoo.global.exception.handleException.block.BlockOwnerMismatchException;
 import com.joojoo.global.exception.handleException.block.InvalidBlockStructureException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -41,4 +43,10 @@ public class BlockValidator {
         }
     }
 
+    /** 현재 블럭의 작성자 여부 검증 */
+    public void validateOwner(Block targetBlock, Long userId) {
+        if (!targetBlock.getUser().getId().equals(userId)) {
+            throw new BlockOwnerMismatchException();
+        }
+    }
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/persistence/BlockRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/persistence/BlockRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.joojoo.api.block.infrastructure.queryDsl.BlockQueryDslRepository;
 import com.joojoo.api.block.infrastructure.queryDsl.date.blockQueryDslDateRepository;
 import com.joojoo.api.block.infrastructure.rdbms.BlockJpaRepository;
 import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.global.exception.handleException.block.BlockNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -58,6 +59,12 @@ public class BlockRepositoryImpl implements BlockRepository {
     }
 
     @Override
+    public Block getBlockById(Long blockId) {
+        return blockJpaRepository.findById(blockId)
+                .orElseThrow(BlockNotFoundException::new);
+    }
+
+    @Override
     public void delete(Block targetBlock) {
         blockJpaRepository.delete(targetBlock);
     }
@@ -91,6 +98,5 @@ public class BlockRepositoryImpl implements BlockRepository {
     public void deleteAllBlockMappings(Long userId) {
         blockQueryDslRepository.deleteAllBlockMappings(userId);
     }
-
 
 }

--- a/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
+++ b/src/main/java/com/joojoo/api/block/presentation/controller/BlockController.java
@@ -3,6 +3,7 @@ package com.joojoo.api.block.presentation.controller;
 import com.joojoo.api.block.application.BlockService;
 import com.joojoo.api.block.application.port.in.CreateBlockUseCase;
 import com.joojoo.api.block.application.port.in.GetBlockUseCase;
+import com.joojoo.api.block.application.port.in.UpdateBlockUseCase;
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.request.updateBlock.BlockUpdateDto;
@@ -33,8 +34,9 @@ public class BlockController {
 
     private final BlockService blockService;
 
-    private final CreateBlockUseCase createBlockUseCase;
     private final GetBlockUseCase getBlockUseCase;
+    private final CreateBlockUseCase createBlockUseCase;
+    private final UpdateBlockUseCase updateBlockUseCase;
 
     @Operation(summary = "블럭(노트) 생성 API", description = "사용자가 작성한 블럭(노트) 트리 구조를 받아 저장합니다.")
     @ApiResponses({
@@ -72,7 +74,6 @@ public class BlockController {
     })
     @GetMapping("/detail/{blockId}")
     public BaseResponse<BlockDetailResponseDto> getBlockDetail(@PathVariable Long blockId) {
-//        return BaseResponse.ok(blockService.getBlockDetail(blockId));
         return BaseResponse.ok(getBlockUseCase.getBlockDetail(blockId));
     }
 
@@ -149,7 +150,7 @@ public class BlockController {
             @PathVariable Long blockId,
             @RequestBody BlockUpdateDto blockUpdateDto
     ) {
-        blockService.updateBlock(user.getUserId(), blockId, blockUpdateDto);
+        updateBlockUseCase.updateBlock(user.getUserId(), blockId, blockUpdateDto);
         return BaseResponse.ok("수정 성공!");
     }
 

--- a/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
@@ -27,7 +27,7 @@ public interface BlockTagRepository {
     /** 2일치 날짜 조회해서 사용한 태그들 조회 */
     TagDateResult findAllByTagAndDate(Long userId, Long tagId, LocalDate targetDate);
 
-    /** TradeLog에서 사용한 태그들 조회 */
+    /** TradeLog에서 사용한 태그들 IN절 조회 */
     List<BlockTag> findAllTagsByTradeLogIds(List<Long> tradeLogIds);
 
     /** 사용자가 사용한 태그를 Redis에 저장 */
@@ -36,8 +36,11 @@ public interface BlockTagRepository {
     /** 사용자가 삭제한 태그를 Redis에 삭제 */
     void removeTagsFromRedis(Long userId, Long tagId, Set<String> lexEntries, int countToRemove);
 
-    /** 삭제할 블럭아이디의 연관된 태그들 조회 */
+    /** 삭제할 블럭아이디의 연관된 태그들 IN절 조회 */
     List<BlockTag> findAllByBlockIdIn(List<Long> blockIds);
+
+    /** blockId와 연관된 태그들 단일 조회 */
+    List<BlockTag> findAllTagsByBlockId(Long blockId);
 
     /** 내가 사용하고있는 태그들 검색 */
     Set<String> searchTagQuery(String prefix);

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
@@ -16,4 +16,6 @@ public interface BlockTagQueryDslRepository {
     List<BlockTag> findAllTagsByTradeLogIds(List<Long> tradeLogIds);
 
     List<BlockTag> findAllByBlockIdIn(List<Long> blockIds);
+
+    List<BlockTag> findAllTagsByBlockId(Long blockId);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
@@ -85,4 +85,17 @@ public class BlockTagQueryDslRepositoryImpl implements BlockTagQueryDslRepositor
                 .where(blockTag.block.id.in(blockIds))
                 .fetch();
     }
+
+    @Override
+    public List<BlockTag> findAllTagsByBlockId(Long blockId) {
+        if (blockId == null) {
+            return Collections.emptyList();
+        }
+
+        return queryFactory
+                .selectFrom(blockTag)
+                .join(blockTag.tag, tag).fetchJoin()
+                .where(blockTag.block.id.eq(blockId))
+                .fetch();
+    }
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/rdbms/BlockTagRepositoryImpl.java
@@ -77,6 +77,11 @@ public class BlockTagRepositoryImpl implements BlockTagRepository {
     }
 
     @Override
+    public List<BlockTag> findAllTagsByBlockId(Long blockId) {
+        return blockTagQueryDslRepository.findAllTagsByBlockId(blockId);
+    }
+
+    @Override
     public Set<String> searchTagQuery(String prefix) {
         return blockTagRedisRepository.searchTagQuery(prefix);
     }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/redis/BlockTagRedisRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/redis/BlockTagRedisRepository.java
@@ -1,7 +1,5 @@
 package com.joojoo.api.blockTag.infrastructure.redis;
 
-import org.springframework.data.redis.connection.Limit;
-
 import java.util.Set;
 
 public interface BlockTagRedisRepository {

--- a/src/main/java/com/joojoo/api/metadata/application/port/in/MetadataUseCase.java
+++ b/src/main/java/com/joojoo/api/metadata/application/port/in/MetadataUseCase.java
@@ -5,5 +5,9 @@ import com.joojoo.api.block.domain.model.entity.Block;
 import java.util.List;
 
 public interface MetadataUseCase {
+    /** List<Block> 타입으로 티커, 태그 찾기 */
     void processMetadata(List<Block> allBlocks, Long userId);
+
+    /** Block 단일 타입으로 티커, 태그 찾기 (수정용) */
+    void processMetadata(Block targetBlock, Long userId);
 }

--- a/src/main/java/com/joojoo/api/metadata/application/port/out/MetadataPort.java
+++ b/src/main/java/com/joojoo/api/metadata/application/port/out/MetadataPort.java
@@ -15,13 +15,13 @@ public interface MetadataPort {
     /** 회원이 사용한 태그를 Redis에 저장 */
     void syncUserTagsToRedis(Long userId, Map<String, Tag> tagMap);
 
+    /** 회원이 블럭에서 사용한 태크들을 Redis에서 삭제 */
+    void processRedisTagRemoval(Long userId, List<BlockTag> oldTags);
+
     /** blockId와 연관된 태그들 조회 */
     List<BlockTag> findAllTagsByBlockId(Long blockId);
 
     /** BlockId 연관된 BlockTag, BlockTicker 삭제  */
     void deleteMetadataByBlockId(Long blockId);
-
-    /** 회원이 블럭에서 사용한 태크들을 Redis에서 삭제 */
-    void processRedisTagRemoval(Long userId, List<BlockTag> oldTags);
 
 }

--- a/src/main/java/com/joojoo/api/metadata/application/port/out/MetadataPort.java
+++ b/src/main/java/com/joojoo/api/metadata/application/port/out/MetadataPort.java
@@ -14,4 +14,14 @@ public interface MetadataPort {
 
     /** 회원이 사용한 태그를 Redis에 저장 */
     void syncUserTagsToRedis(Long userId, Map<String, Tag> tagMap);
+
+    /** blockId와 연관된 태그들 조회 */
+    List<BlockTag> findAllTagsByBlockId(Long blockId);
+
+    /** BlockId 연관된 BlockTag, BlockTicker 삭제  */
+    void deleteMetadataByBlockId(Long blockId);
+
+    /** 회원이 블럭에서 사용한 태크들을 Redis에서 삭제 */
+    void processRedisTagRemoval(Long userId, List<BlockTag> oldTags);
+
 }

--- a/src/main/java/com/joojoo/api/metadata/application/service/MetadataUseCaseService.java
+++ b/src/main/java/com/joojoo/api/metadata/application/service/MetadataUseCaseService.java
@@ -8,15 +8,16 @@ import com.joojoo.api.metadata.application.port.in.MetadataUseCase;
 import com.joojoo.api.metadata.application.port.out.MetadataPort;
 import com.joojoo.api.metadata.domain.service.MetadataAnalyzer;
 import com.joojoo.api.tag.application.in.TagInService;
+import com.joojoo.api.tag.domain.model.entity.Tag;
 import com.joojoo.api.ticker.application.in.TickerInService;
 import com.joojoo.api.util.metadata.MetadataContext;
+import com.joojoo.global.util.HangulUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +56,20 @@ public class MetadataUseCaseService implements MetadataUseCase {
         if (!context.getTagNames().isEmpty()) {
             metadataPort.syncUserTagsToRedis(userId, context.getTagMap());
         }
+    }
+
+    @Override
+    @Transactional
+    public void processMetadata(Block targetBlock, Long userId) {
+        List<BlockTag> oldTags = metadataPort.findAllTagsByBlockId(targetBlock.getId()); // 메서드명 변경
+
+        // 연관된 티커 태그 삭제
+        metadataPort.deleteMetadataByBlockId(targetBlock.getId());
+
+        if (!oldTags.isEmpty()) {
+            metadataPort.processRedisTagRemoval(userId, oldTags);
+        }
+        this.processMetadata(Collections.singletonList(targetBlock), userId);
     }
 
 }

--- a/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
+++ b/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
@@ -20,6 +20,7 @@ public class MetadataPersistenceAdapter implements MetadataPort { // User 도메
 
     private final BlockTickerRepository blockTickerRepository;
     private final BlockTagRepository blockTagRepository;
+    private final BlockTagRedisRepository blockTagRedisRepository;
 
     @Override
     public void saveTickersAndTags(List<BlockTicker> tickers, List<BlockTag> tags) {
@@ -33,13 +34,32 @@ public class MetadataPersistenceAdapter implements MetadataPort { // User 도메
         Set<Long> tagIds = new HashSet<>();
 
         tagMap.forEach((name, tag) -> {
-            Long tagId = tag.getId();
-            lexEntries.add(userId + ":" + HangulUtils.splitToJaso(name) + "*" + name + "*" + tagId);
-            lexEntries.add(userId + ":" + HangulUtils.getChosung(name) + "*" + name + "*" + tagId);
-            tagIds.add(tagId);
+            lexEntries.addAll(generateLexEntries(userId, name, tag.getId()));
+            tagIds.add(tag.getId());
         });
 
-        blockTagRepository.addTagsToRedis(userId, lexEntries, tagIds);
+        blockTagRedisRepository.addTagsToRedis(userId, lexEntries, tagIds);
+    }
+
+    @Override
+    public void processRedisTagRemoval(Long userId, List<BlockTag> oldTags) {
+        Map<Tag, Long> tagCounts = oldTags.stream()
+                .collect(Collectors.groupingBy(BlockTag::getTag, Collectors.counting()));
+
+        tagCounts.forEach((tag, count) -> {
+            Set<String> lexEntries = generateLexEntries(userId, tag.getName(), tag.getId());
+            blockTagRedisRepository.removeTagsFromRedis(userId, tag.getId(), lexEntries, count.intValue());
+        });
+    }
+
+    /** Redis Tag Key 생성 로직 */
+    private Set<String> generateLexEntries(Long userId, String name, Long tagId) {
+        String base = "*" + name + "*" + tagId;
+
+        return Set.of(
+                userId + ":" + HangulUtils.splitToJaso(name) + base,
+                userId + ":" + HangulUtils.getChosung(name) + base
+        );
     }
 
     @Override
@@ -51,24 +71,6 @@ public class MetadataPersistenceAdapter implements MetadataPort { // User 도메
     public void deleteMetadataByBlockId(Long blockId) {
         blockTickerRepository.deleteByBlockIds(blockId);
         blockTagRepository.deleteByBlockIds(blockId);
-    }
-
-    @Override
-    public void processRedisTagRemoval(Long userId, List<BlockTag> oldTags) {
-        Map<Long, List<BlockTag>> groupedTags = oldTags.stream()
-                .collect(Collectors.groupingBy(bt -> bt.getTag().getId()));
-
-        groupedTags.forEach((tagId, tags) -> {
-            Tag tag = tags.get(0).getTag();
-            String name = tag.getName();
-            int countToRemove = tags.size();
-
-            Set<String> lexEntries = new HashSet<>();
-            lexEntries.add(userId + ":" + HangulUtils.splitToJaso(name) + "*" + name + "*" + tagId);
-            lexEntries.add(userId + ":" + HangulUtils.getChosung(name) + "*" + name + "*" + tagId);
-
-            blockTagRepository.removeTagsFromRedis(userId, tagId, lexEntries, countToRemove);
-        });
     }
 
 }

--- a/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
+++ b/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.joojoo.api.metadata.infrastructure.persistence;
 
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.blockTag.infrastructure.redis.BlockTagRedisRepository;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
 import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import com.joojoo.api.metadata.application.port.out.MetadataPort;
@@ -10,10 +11,8 @@ import com.joojoo.global.util.HangulUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -41,6 +40,35 @@ public class MetadataPersistenceAdapter implements MetadataPort { // User 도메
         });
 
         blockTagRepository.addTagsToRedis(userId, lexEntries, tagIds);
+    }
+
+    @Override
+    public List<BlockTag> findAllTagsByBlockId(Long blockId) {
+        return blockTagRepository.findAllTagsByBlockId(blockId);
+    }
+
+    @Override
+    public void deleteMetadataByBlockId(Long blockId) {
+        blockTickerRepository.deleteByBlockIds(blockId);
+        blockTagRepository.deleteByBlockIds(blockId);
+    }
+
+    @Override
+    public void processRedisTagRemoval(Long userId, List<BlockTag> oldTags) {
+        Map<Long, List<BlockTag>> groupedTags = oldTags.stream()
+                .collect(Collectors.groupingBy(bt -> bt.getTag().getId()));
+
+        groupedTags.forEach((tagId, tags) -> {
+            Tag tag = tags.get(0).getTag();
+            String name = tag.getName();
+            int countToRemove = tags.size();
+
+            Set<String> lexEntries = new HashSet<>();
+            lexEntries.add(userId + ":" + HangulUtils.splitToJaso(name) + "*" + name + "*" + tagId);
+            lexEntries.add(userId + ":" + HangulUtils.getChosung(name) + "*" + name + "*" + tagId);
+
+            blockTagRepository.removeTagsFromRedis(userId, tagId, lexEntries, countToRemove);
+        });
     }
 
 }


### PR DESCRIPTION
## 📌 PR 제목
- [Refactor] 메타데이터(Tag/Ticker) 처리 로직 고도화 및 Redis 색인 구조 리팩토링

---

## 📝 작업 개요
블록 수정 시 발생하는 메타데이터 분석 및 저장 로직을 정리하고, Redis 자동완성용 키 생성 로직의 중복을 제거하여 코드의 유지보수성과 정합성을 높였습니다.

---

## 🛠 작업 내용

### 1. `MetadataUseCaseService` 계층 간 책임 분리
- **Port 인터페이스 활용**: Repository를 직접 참조하던 로직을 `MetadataPort`로 추상화하여 헥사고날 아키텍처의 의존성 원칙을 준수했습니다.
- **메서드 세분화**: 단일 블록 처리(`processMetadata`) 시 기존 데이터를 삭제하고 재분석하는 흐름을 포트 메서드로 캡슐화했습니다.

### 2. Redis 색인 키 생성 로직 최적화
- **`generateLexEntries` 추출**: 검색용 키 생성 규칙(초성/자소 분리)을 별도 메서드로 공통화하여 생성(`sync`)과 삭제(`removal`) 시 동일한 키 포맷을 보장합니다.
- **가독성 및 정합성 향상**: 하드코딩된 문자열 조작 로직을 제거하고, 예시 중심의 주석을 추가하여 검색 인덱스 구조를 명확히 했습니다.

### 3. 메타데이터 조회 및 삭제 성능 개선
- **단일 조회 메서드 도입**: `findAllTagsByBlockId`를 신설하여 단일 블록 처리 시 불필요한 `IN` 절 사용을 지양하고 `EQ` 연산을 통해 쿼리 효율을 높였습니다.
- **스트림 기반 카운팅**: `Collectors.groupingBy`와 `counting()`을 활용하여 삭제할 메타데이터의 수량을 더 선언적이고 안전하게 계산합니다.
