### PR TITLE
Feature/social login consent

### DIFF
--- a/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCase.java
+++ b/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCase.java
@@ -6,10 +6,10 @@ import jakarta.servlet.http.HttpServletRequest;
 
 public interface JwtTokenUseCase {
     // RefreshToken 생성 및 DB 저장
-    String createAndSaveRefreshToken(Long userId, String userName, User user);
+    String createAndSaveRefreshToken(Long userId, String userName, User user, String role);
 
     // AccessToken 생성
-    String createAccessToken(Long userId, String userName);
+    String createAccessToken(Long userId, String userName, String role);
 
     // 로그아웃시 토큰 블랙리스트 삽입 및 DB제거
     void clearUserTokens(Long userId, HttpServletRequest request);

--- a/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCaseImpl.java
+++ b/src/main/java/com/joojoo/api/jwt/application/JwtTokenUseCaseImpl.java
@@ -33,8 +33,8 @@ public class JwtTokenUseCaseImpl implements JwtTokenUseCase {
 
     @Override
     @Transactional
-    public String createAndSaveRefreshToken(Long userId, String userName, User user) {
-        String refreshToken = jwtProvider.createRefreshToken(userId, userName);
+    public String createAndSaveRefreshToken(Long userId, String userName, User user, String role) {
+        String refreshToken = jwtProvider.createRefreshToken(userId, userName, role);
         LocalDateTime expiresAt = TokenExpirationUtil.toLocalDateTime(jwtProvider.getExpiration(refreshToken));
 
         registerRefreshToken(user, refreshToken, expiresAt);
@@ -54,8 +54,8 @@ public class JwtTokenUseCaseImpl implements JwtTokenUseCase {
     }
 
     @Override
-    public String createAccessToken(Long userId, String userName) {
-        return jwtProvider.createAccessToken(userId, userName);
+    public String createAccessToken(Long userId, String userName, String role) {
+        return jwtProvider.createAccessToken(userId, userName, role);
     }
 
     @Override
@@ -78,7 +78,7 @@ public class JwtTokenUseCaseImpl implements JwtTokenUseCase {
                 .orElseThrow(RefreshTokenExpiredException::new);
 
         storedToken.validateSameToken(refreshToken);
-        return new ReissueTokenResponse(jwtProvider.createAccessToken(userDetails.getUserId(), userDetails.getUsername()));
+        return new ReissueTokenResponse(jwtProvider.createAccessToken(userDetails.getUserId(), userDetails.getUsername(), userDetails.getRole()));
     }
 
     private void validateToken(String refreshToken) {

--- a/src/main/java/com/joojoo/api/jwt/domain/service/JwtProvider.java
+++ b/src/main/java/com/joojoo/api/jwt/domain/service/JwtProvider.java
@@ -7,10 +7,10 @@ import java.util.Date;
 
 public interface JwtProvider {
     // AccessToken 생성
-    String createAccessToken(Long userId, String userName);
+    String createAccessToken(Long userId, String userName, String role);
 
     // RefreshToken 생성
-    String createRefreshToken(Long userId, String userName);
+    String createRefreshToken(Long userId, String userName, String role);
 
     // 해더에서 토큰 추출
     String extractBearerToken(HttpServletRequest request);

--- a/src/main/java/com/joojoo/api/jwt/infrastructure/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/joojoo/api/jwt/infrastructure/jwt/JwtProviderImpl.java
@@ -37,19 +37,21 @@ public class JwtProviderImpl implements JwtProvider {
     }
 
     @Override
-    public String createAccessToken(Long userId, String userName) {
+    public String createAccessToken(Long userId, String userName, String role) {
         Claims claims = Jwts.claims()
                 .subject(userName)
                 .add("userId", userId) // 여기서 값을 추가합니다
+                .add("role", role)
                 .build();
         return createToken(claims, accessTokenValidity);
     }
 
     @Override
-    public String createRefreshToken(Long userId, String userName) {
+    public String createRefreshToken(Long userId, String userName, String role) {
         Claims claims = Jwts.claims()
                 .subject(userName)
                 .add("userId", userId)
+                .add("role", role)
                 .build();
 
         return createToken(claims, refreshTokenValidity);
@@ -103,9 +105,10 @@ public class JwtProviderImpl implements JwtProvider {
             throw new TokenVerificationException();
         }
         Long userId = Long.valueOf(claims.get("userId").toString());
+        String role = claims.get("role").toString();
 
-        CustomUserDetails user = new CustomUserDetails(userId, username);
-        return new UsernamePasswordAuthenticationToken(user, "", List.of());
+        CustomUserDetails user = new CustomUserDetails(userId, username, role);
+        return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
     }
 
     @Override

--- a/src/main/java/com/joojoo/api/user/application/port/in/UpdateUserUseCase.java
+++ b/src/main/java/com/joojoo/api/user/application/port/in/UpdateUserUseCase.java
@@ -7,4 +7,7 @@ public interface UpdateUserUseCase {
 
     /** 회원 이름, 프로필 업데이트 */
     UserInfoResponse updateProfile(Long userId, UpdateProfileDto updateProfileDto);
+
+    /** 회원 동의 승인 시 권한 업데이트 */
+    void completeSignup(Long userId);
 }

--- a/src/main/java/com/joojoo/api/user/application/port/in/UpdateUserUseCase.java
+++ b/src/main/java/com/joojoo/api/user/application/port/in/UpdateUserUseCase.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.user.application.port.in;
 
 import com.joojoo.api.user.presentation.dto.request.UpdateProfileDto;
+import com.joojoo.api.user.presentation.dto.response.LoginResponse;
 import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
 
 public interface UpdateUserUseCase {
@@ -9,5 +10,5 @@ public interface UpdateUserUseCase {
     UserInfoResponse updateProfile(Long userId, UpdateProfileDto updateProfileDto);
 
     /** 회원 동의 승인 시 권한 업데이트 */
-    void completeSignup(Long userId);
+    LoginResponse completeSignup(Long userId);
 }

--- a/src/main/java/com/joojoo/api/user/application/service/command/SocialLoginService.java
+++ b/src/main/java/com/joojoo/api/user/application/service/command/SocialLoginService.java
@@ -83,8 +83,8 @@ public class SocialLoginService implements SocialLoginUseCase {
     }
 
     private LoginResponse generateLoginResponse(User user){
-        String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user);
-        String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName());
+        String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user, user.getRole().name());
+        String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName(), user.getRole().name());
         return LoginResponse.of(user, accessToken, refreshToken);
     }
 

--- a/src/main/java/com/joojoo/api/user/application/service/command/UserUpdateService.java
+++ b/src/main/java/com/joojoo/api/user/application/service/command/UserUpdateService.java
@@ -31,4 +31,11 @@ public class UserUpdateService implements UpdateUserUseCase  {
 
         return UserInfoResponse.of(user, filePort.getFullUrl(user.getProfileImageUrl()));
     }
+
+    @Override
+    public void completeSignup(Long userId) {
+        User user = userRepository.getUserById(userId);
+        user.activateUser();
+    }
+
 }

--- a/src/main/java/com/joojoo/api/user/application/service/command/UserUpdateService.java
+++ b/src/main/java/com/joojoo/api/user/application/service/command/UserUpdateService.java
@@ -1,11 +1,13 @@
 package com.joojoo.api.user.application.service.command;
 
+import com.joojoo.api.jwt.application.JwtTokenUseCase;
 import com.joojoo.api.user.application.port.in.UpdateUserUseCase;
 import com.joojoo.api.user.application.port.out.file.FilePort;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
 import com.joojoo.api.user.domain.service.UserValidator;
 import com.joojoo.api.user.presentation.dto.request.UpdateProfileDto;
+import com.joojoo.api.user.presentation.dto.response.LoginResponse;
 import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,7 @@ public class UserUpdateService implements UpdateUserUseCase  {
     private final UserRepository userRepository;
     private final UserValidator userValidator;
     private final FilePort filePort;
+    private final JwtTokenUseCase jwtTokenUseCase;
 
     @Override
     public UserInfoResponse updateProfile(Long userId, UpdateProfileDto dto) {
@@ -33,9 +36,16 @@ public class UserUpdateService implements UpdateUserUseCase  {
     }
 
     @Override
-    public void completeSignup(Long userId) {
+    public LoginResponse completeSignup(Long userId) {
         User user = userRepository.getUserById(userId);
         user.activateUser();
+        return generateLoginResponse(user);
+    }
+
+    private LoginResponse generateLoginResponse(User user){
+        String refreshToken = jwtTokenUseCase.createAndSaveRefreshToken(user.getId(), user.getName(), user, user.getRole().name());
+        String accessToken = jwtTokenUseCase.createAccessToken(user.getId(), user.getName(), user.getRole().name());
+        return LoginResponse.of(user, accessToken, refreshToken);
     }
 
 }

--- a/src/main/java/com/joojoo/api/user/domain/model/entity/User.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/entity/User.java
@@ -70,7 +70,7 @@ public class User extends BaseTimeEntity {
             .profileImageUrl(kakaoUser.getProfileImageUrl())
             .provider(Provider.KAKAO)
             .currency(Currency.KRW)
-            .role(Role.USER)
+            .role(Role.PENDING)
             .providerId(kakaoUser.getProviderId())
             .socialRefresh(socialRefreshToken)
             .build();
@@ -84,7 +84,7 @@ public class User extends BaseTimeEntity {
                 .providerId(providerId)
                 .socialRefresh(appleRefreshToken)
                 .currency(Currency.KRW)
-                .role(Role.USER)
+                .role(Role.PENDING)
                 .build();
     }
 

--- a/src/main/java/com/joojoo/api/user/domain/model/entity/User.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/entity/User.java
@@ -7,6 +7,7 @@ import com.joojoo.api.user.domain.model.enums.Role;
 import com.joojoo.api.user.presentation.dto.request.kakao.KakaoUserDto;
 import com.joojoo.global.common.entity.BaseTimeEntity;
 import com.joojoo.global.exception.handleException.users.AdminOnlyAccessException;
+import com.joojoo.global.exception.handleException.users.UserAlreadyActivatedException;
 import com.joojoo.global.exception.handleException.users.UserNameRequiredException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -123,5 +124,12 @@ public class User extends BaseTimeEntity {
         } else if (this.profileImageUrl == null) {
             this.profileImageUrl = DefaultProfileImage.PROFILE_1.getFileName();
         }
+    }
+
+    public void activateUser() {
+        if (this.role != Role.PENDING) {
+            throw new UserAlreadyActivatedException();
+        }
+        this.role = Role.USER;
     }
 }

--- a/src/main/java/com/joojoo/api/user/domain/model/enums/Role.java
+++ b/src/main/java/com/joojoo/api/user/domain/model/enums/Role.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum Role {
 
     USER("회원"),
+    PENDING("대기"),
     ADMIN("관리자"),
     ;
 

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -169,10 +169,13 @@ public class UserController {
         return BaseResponse.ok(getUserUseCase.getUserInfo(user.getUserId()));
     }
 
+    @Operation(summary = "동의 화면 API", description = "동의 항목 동의 성공시 회원 토큰으로 응답")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 권한 변경 성공")
+    })
     @PostMapping("/consent")
-    public BaseResponse<String> completeSignup(@AuthenticationPrincipal CustomUserDetails user){
-        updateUserUseCase.completeSignup(user.getUserId());
-        return BaseResponse.ok("OK");
+    public BaseResponse<LoginResponse> completeSignup(@AuthenticationPrincipal CustomUserDetails user){
+        return BaseResponse.ok(updateUserUseCase.completeSignup(user.getUserId()));
     }
 
 }

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -169,4 +169,10 @@ public class UserController {
         return BaseResponse.ok(getUserUseCase.getUserInfo(user.getUserId()));
     }
 
+    @PostMapping("/consent")
+    public BaseResponse<String> completeSignup(@AuthenticationPrincipal CustomUserDetails user){
+        updateUserUseCase.completeSignup(user.getUserId());
+        return BaseResponse.ok("OK");
+    }
+
 }

--- a/src/main/java/com/joojoo/api/user/presentation/dto/response/LoginResponse.java
+++ b/src/main/java/com/joojoo/api/user/presentation/dto/response/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.user.presentation.dto.response;
 
 import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.api.user.domain.model.enums.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponse {
     private Long id;
+    private Role role;
     private String email;
     private String name;
     private String profileImageUrl;
@@ -18,12 +20,13 @@ public class LoginResponse {
 
     public static LoginResponse of(User user, String accessToken, String refreshToken) {
         return LoginResponse.builder()
-            .id(user.getId())
-            .email(user.getEmail())
-            .name(user.getName())
-            .profileImageUrl(user.getProfileImageUrl())
-            .accessToken(accessToken)
-            .refreshToken(refreshToken)
-            .build();
+                .id(user.getId())
+                .role(user.getRole())
+                .email(user.getEmail())
+                .name(user.getName())
+                .profileImageUrl(user.getProfileImageUrl())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 }

--- a/src/main/java/com/joojoo/global/common/request/auth/CustomUserDetails.java
+++ b/src/main/java/com/joojoo/global/common/request/auth/CustomUserDetails.java
@@ -5,9 +5,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.List;
 
 @Getter
 @ToString
@@ -17,10 +19,11 @@ public class CustomUserDetails implements UserDetails {
 
     private Long userId;
     private String userName;
+    private String role;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return List.of(new SimpleGrantedAuthority("ROLE_" + this.role));
     }
 
     @Override

--- a/src/main/java/com/joojoo/global/config/SecurityConfig.java
+++ b/src/main/java/com/joojoo/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.joojoo.global.config;
 
 import com.joojoo.api.jwt.domain.repository.TokenBlacklistRepository;
 import com.joojoo.api.jwt.domain.service.JwtProvider;
+import com.joojoo.global.exception.authentication.CustomAccessDeniedHandler;
 import com.joojoo.global.exception.authentication.CustomAuthenticationEntryPoint;
 import com.joojoo.global.jwt.filter.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
@@ -40,15 +41,19 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource))
 
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/user/kakao/login", "/user/apple/login", "/user/apple/web/login", "/user/apple/android/login", "/token/reissue").permitAll()
-                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
-                .requestMatchers("/health/**").permitAll()
-                .anyRequest().authenticated()
+                    .requestMatchers("/user/kakao/login", "/user/apple/login", "/user/apple/web/login", "/user/apple/android/login", "/token/reissue").permitAll()
+                    .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/health/**").permitAll()
+
+                    // 가입 대기자(PENDING)만 접근 가능한 API
+                    .requestMatchers("/user/consent").hasRole("PENDING")
+
+                    .anyRequest().hasAnyRole("USER", "ADMIN")
             )
 
+            // Security 에서 걸린 애들 즉, authenticated()에 로그인을 안한 애들은 예외처리
             .exceptionHandling(ex -> ex
-                // Security 에서 걸린 애들 즉, authenticated()에 로그인을 안한 애들은 예외처리
-                .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                    .authenticationEntryPoint(new CustomAuthenticationEntryPoint()) // 401
+                    .accessDeniedHandler(new CustomAccessDeniedHandler()) // 403
             )
 
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/joojoo/global/exception/authentication/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/joojoo/global/exception/authentication/CustomAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package com.joojoo.global.exception.authentication;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null) {
+            System.out.println("현재 유저 권한: " + auth.getAuthorities());
+        }
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, String> responseBody = new HashMap<>();
+        responseBody.put("error", "추가 동의가 필요한 사용자입니다.");
+
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+    }
+}

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     ADMIN_ONLY(403, "ADMIN_ONLY", "관리자 권한이 필요합니다."),
     USER_NAME_REQUIRED(400, "USER_NAME_REQUIRED", "초기 설정 시 닉네임은 필수입니다."),
     USER_NAME_DUPLICATED(409, "USER_NAME_DUPLICATED", "이미 사용 중인 닉네임입니다."),
+    USER_ALREADY_ACTIVATED(400, "USER_ALREADY_ACTIVATED", "이미 가입이 완료된 회원이거나 변경할 수 없는 상태입니다."),
 
     // ───────────────────────────── 인증/인가(auth) ─────────────────────────────
     INVALID_AUTHORIZATION_CODE(400, "INVALID_AUTHORIZATION_CODE", "유효하지 않은 인가 코드입니다."),

--- a/src/main/java/com/joojoo/global/exception/handleException/users/UserAlreadyActivatedException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/users/UserAlreadyActivatedException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.users;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class UserAlreadyActivatedException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.USER_ALREADY_ACTIVATED;
+
+    public UserAlreadyActivatedException() {
+        super(errorCode);
+    }
+
+    public UserAlreadyActivatedException(Exception exception) {
+        super(errorCode, exception);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 소셜 로그인 신규 회원 동의 프로세스 구현 및 유저 상태 권한 제어

## 작업 개요

소셜 로그인 시 신규 회원을 바로 서비스에 진입시키지 않고, 약관 동의 절차를 거치도록 `PENDING` 상태를 도입하였습니다. 또한, Spring Security를 통해 동의 전 유저의 API 접근을 제한하는 로직을 추가했습니다.

---

## 작업 내용

- **유저 상태(Role) 시스템 도입**
  - `Role` Enum에 `PENDING`(대기), `USER`(일반), `ADMIN`(관리자) 권한 추가
  - 신규 가입 시 기본 권한을 `PENDING`으로 설정하도록 로직 수정

- **소셜 로그인 로직 개선**
  - 기존 회원 여부 및 `PENDING` 여부를 판단하여 `isNewUser` 플래그를 포함한 응답 반환
  - `UserWithStatus` 객체를 통해 DB 조회를 최적화하여 신규/기존 회원 판별

- **Spring Security 권한 제어 설정**
  - `ROLE_PENDING` 권한은 `/user/consent` API만 접근 가능하도록 설정
  - 가입이 완료되지 않은 유저가 일반 API 호출 시 `403 Forbidden`을 반환하는 `CustomAccessDeniedHandler` 구현
  - `CustomUserDetails` 및 `JwtProvider`에서 `ROLE_` 접두사를 포함한 권한 반환 로직 적용

- **회원가입 완료(동의) API 추가**
  - `/user/consent` API: 유저 동의 시 권한을 `PENDING`에서 `USER`로 업데이트
  - 이미 가입 완료된 유저(`USER`, `ADMIN`)가 중복 호출 시 상태 변경을 차단하는 예외 처리 로직 추가

---