### PR TITLE
Refactor/user ddd hexagonal

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/port/in/DeleteBlockUseCase.java
+++ b/src/main/java/com/joojoo/api/block/application/port/in/DeleteBlockUseCase.java
@@ -3,7 +3,5 @@ package com.joojoo.api.block.application.port.in;
 import com.joojoo.api.block.domain.model.enums.DeleteMode;
 
 public interface DeleteBlockUseCase {
-    void deleteAllBlockMappings(Long userId);
-
     void deleteBlock(Long userId, Long blockId, DeleteMode mode);
 }

--- a/src/main/java/com/joojoo/api/block/application/service/command/CreateBlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/service/command/CreateBlockService.java
@@ -9,8 +9,8 @@ import com.joojoo.api.block.domain.service.validation.BlockValidator;
 import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
 import com.joojoo.api.block.presentation.dto.response.blockDetail.BlockResponse;
 import com.joojoo.api.metadata.application.port.in.MetadataUseCase;
-import com.joojoo.api.user.application.port.in.GetUserUseCase;
 import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.api.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +23,7 @@ import java.util.List;
 public class CreateBlockService implements CreateBlockUseCase {
 
     private final BlockRepository blockRepository;
-    private final GetUserUseCase getUserUseCase;
+    private final UserRepository userRepository;
     private final BlockDomainService blockDomainService;
     private final BlockValidator blockValidator;
     private final BlockTreeAssembler blockTreeAssembler;
@@ -32,7 +32,7 @@ public class CreateBlockService implements CreateBlockUseCase {
     @Override
     public BlockResponse saveBlockTree(Long userId, BlockSaveRequestDto requestDto) {
         blockValidator.validateStructure(requestDto);
-        User user = getUserUseCase.getUser(userId);
+        User user = userRepository.getUserById(userId);
 
         List<Block> allBlocks = blockDomainService.createAndSaveBlocks(user, requestDto.getBlocks());
         blockRepository.saveAll(allBlocks); // TODO : JDBC Batch Insert 고려, 지금 블럭이 10개면 10개의 Insert 쿼리 작동 중

--- a/src/main/java/com/joojoo/api/block/application/service/command/DeleteBlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/service/command/DeleteBlockService.java
@@ -27,11 +27,6 @@ public class DeleteBlockService implements DeleteBlockUseCase {
     private final BlockDomainService blockDomainService;
 
     @Override
-    public void deleteAllBlockMappings(Long userId) {
-        blockRepository.deleteAllBlockMappings(userId);
-    }
-
-    @Override
     @Transactional
     public void deleteBlock(Long userId, Long blockId, DeleteMode mode) {
         // 블록 조회 및 권한 검증

--- a/src/main/java/com/joojoo/api/tradeLog/application/port/in/DeleteTradeLogUseCase.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/port/in/DeleteTradeLogUseCase.java
@@ -1,5 +1,4 @@
 package com.joojoo.api.tradeLog.application.port.in;
 
 public interface DeleteTradeLogUseCase {
-    void withdrawByUserId(Long userId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/application/service/command/DeleteTradeLogService.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/service/command/DeleteTradeLogService.java
@@ -1,7 +1,6 @@
 package com.joojoo.api.tradeLog.application.service.command;
 
 import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
-import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,10 +8,5 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DeleteTradeLogService implements DeleteTradeLogUseCase {
 
-    private final TradeLogRepository tradeLogRepository;
 
-    @Override
-    public void withdrawByUserId(Long userId) {
-        tradeLogRepository.withdrawByUserId(userId);
-    }
 }

--- a/src/main/java/com/joojoo/api/user/application/port/in/GetUserUseCase.java
+++ b/src/main/java/com/joojoo/api/user/application/port/in/GetUserUseCase.java
@@ -6,9 +6,6 @@ import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
 
 /** 회원을 조회하는 인터페이스 */
 public interface GetUserUseCase {
-    /** 회원 조회 */
-    User getUser(Long userId);
-
     /** 회원 프록시 객체 */
     User getUserReference(Long userId);
 

--- a/src/main/java/com/joojoo/api/user/application/port/out/social/AppleWebClientSecret.java
+++ b/src/main/java/com/joojoo/api/user/application/port/out/social/AppleWebClientSecret.java
@@ -1,0 +1,9 @@
+package com.joojoo.api.user.application.port.out.social;
+
+import com.joojoo.api.user.presentation.dto.request.apple.AppleTokenResponse;
+
+public interface AppleWebClientSecret {
+    String createClientSecret();
+
+    AppleTokenResponse requestAppleToken(String code, String clientSecret);
+}

--- a/src/main/java/com/joojoo/api/user/application/port/out/social/SocialUnlink.java
+++ b/src/main/java/com/joojoo/api/user/application/port/out/social/SocialUnlink.java
@@ -1,4 +1,4 @@
-package com.joojoo.api.user.application.auth.withdraw.out;
+package com.joojoo.api.user.application.port.out.social;
 
 import com.joojoo.api.user.domain.model.entity.User;
 

--- a/src/main/java/com/joojoo/api/user/application/service/command/SocialLoginService.java
+++ b/src/main/java/com/joojoo/api/user/application/service/command/SocialLoginService.java
@@ -3,7 +3,7 @@ package com.joojoo.api.user.application.service.command;
 import com.joojoo.api.jwt.application.JwtTokenUseCase;
 import com.joojoo.api.user.application.port.in.SocialLoginUseCase;
 import com.joojoo.api.user.application.port.out.social.AppleClientSecret;
-import com.joojoo.api.user.application.port.out.social.AppleWeb;
+import com.joojoo.api.user.application.port.out.social.AppleWebClientSecret;
 import com.joojoo.api.user.application.port.out.social.KakaoClientSecret;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.service.UserDomainService;
@@ -25,6 +25,7 @@ public class SocialLoginService implements SocialLoginUseCase {
     private final UserDomainService userDomainService;
     private final KakaoClientSecret kakaoClientSecret;
     private final AppleClientSecret appleClientSecret;
+    private final AppleWebClientSecret appleWebClientSecret;
 
     @Override
     @Transactional
@@ -55,15 +56,13 @@ public class SocialLoginService implements SocialLoginUseCase {
         return generateLoginResponse(user);
     }
 
-    private final AppleWeb appleWeb;
-
     @Override
     public LoginResponse appleWebLogin(String code) {
         // Client Secret 생성
-        String clientSecret = appleWeb.createClientSecret();
+        String clientSecret = appleWebClientSecret.createClientSecret();
 
         // 애플 토큰 요청 (redirectUri 포함)
-        AppleTokenResponse appleTokenResponse = appleWeb.requestAppleToken(code, clientSecret);
+        AppleTokenResponse appleTokenResponse = appleWebClientSecret.requestAppleToken(code, clientSecret);
         AppleUserInfo appleUser = appleClientSecret.getAppleUserInfo(appleTokenResponse.getIdToken());
 
         User user = userDomainService.registerOrLogin(appleUser.getProviderId(), appleTokenResponse.getRefreshToken(), appleUser.getEmail());

--- a/src/main/java/com/joojoo/api/user/application/service/command/UserWithdrawService.java
+++ b/src/main/java/com/joojoo/api/user/application/service/command/UserWithdrawService.java
@@ -1,8 +1,9 @@
 package com.joojoo.api.user.application.service.command;
 
-import com.joojoo.api.block.application.port.in.DeleteBlockUseCase;
+import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.jwt.application.JwtTokenUseCase;
 import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
+import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import com.joojoo.api.user.application.auth.withdraw.out.SocialUnlink;
 import com.joojoo.api.user.application.port.in.WithdrawUserUseCase;
 import com.joojoo.api.user.domain.model.entity.User;
@@ -21,8 +22,8 @@ public class UserWithdrawService implements WithdrawUserUseCase {
 
     private final UserRepository userRepository;
     private final JwtTokenUseCase jwtTokenUseCase;
-    private final DeleteBlockUseCase deleteBlockUseCase;
-    private final DeleteTradeLogUseCase deleteTradeLogUseCase;
+    private final BlockRepository blockRepository;
+    private final TradeLogRepository tradeLogRepository;
     private final Map<String, SocialUnlink> socialUnlink;
 
     @Override
@@ -30,8 +31,8 @@ public class UserWithdrawService implements WithdrawUserUseCase {
         User user = userRepository.getUserById(userId);
 
         unSocialWithdraw(user); // 소셜 계정 탈퇴
-        deleteBlockUseCase.deleteAllBlockMappings(userId); // 블럭(노트) 연관관계 정리
-        deleteTradeLogUseCase.withdrawByUserId(userId); // 템플릿 정리
+        blockRepository.deleteAllBlockMappings(userId); // 블럭(노트) 연관관계 정리
+        tradeLogRepository.withdrawByUserId(userId); // 템플릿 정리
         jwtTokenUseCase.clearUserTokens(userId, request); // 토큰 정리
         user.withdraw(); // 회원 DB 정리
 

--- a/src/main/java/com/joojoo/api/user/application/service/command/UserWithdrawService.java
+++ b/src/main/java/com/joojoo/api/user/application/service/command/UserWithdrawService.java
@@ -2,9 +2,8 @@ package com.joojoo.api.user.application.service.command;
 
 import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.jwt.application.JwtTokenUseCase;
-import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
-import com.joojoo.api.user.application.auth.withdraw.out.SocialUnlink;
+import com.joojoo.api.user.application.port.out.social.SocialUnlink;
 import com.joojoo.api.user.application.port.in.WithdrawUserUseCase;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;

--- a/src/main/java/com/joojoo/api/user/application/service/query/UserQueryService.java
+++ b/src/main/java/com/joojoo/api/user/application/service/query/UserQueryService.java
@@ -23,12 +23,6 @@ public class UserQueryService implements GetUserUseCase {
     private final FilePort filePort;
 
     @Override
-    public User getUser(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-    }
-
-    @Override
     public User getUserReference(Long userId) {
         try {
             return userRepository.getReferenceById(userId);
@@ -39,7 +33,7 @@ public class UserQueryService implements GetUserUseCase {
 
     @Override
     public UserInfoResponse getUserInfo(Long userId) {
-        User user = this.getUser(userId);
+        User user = userRepository.getUserById(userId);
         return UserInfoResponse.of(user);
     }
 

--- a/src/main/java/com/joojoo/api/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/joojoo/api/user/domain/repository/UserRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 /** UserPort 역할 */
 public interface UserRepository {
-    Optional<User> findByEmail(String email);
     User save(User user);
     Optional<User> findByProviderId(String providerId);
     void delete(User user);

--- a/src/main/java/com/joojoo/api/user/infrastructure/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/persistence/UserPersistenceAdapter.java
@@ -16,11 +16,6 @@ public class UserPersistenceAdapter implements UserRepository {
     private final UserJpaRepository userJpaRepository;
 
     @Override
-    public Optional<User> findByEmail(String email) {
-        return userJpaRepository.findByEmail(email);
-    }
-
-    @Override
     public Optional<User> findByProviderId(String providerId) {
         return userJpaRepository.findByProviderId(providerId);
     }

--- a/src/main/java/com/joojoo/api/user/infrastructure/persistence/file/FileStorageAdapter.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/persistence/file/FileStorageAdapter.java
@@ -1,4 +1,4 @@
-package com.joojoo.api.user.infrastructure.file;
+package com.joojoo.api.user.infrastructure.persistence.file;
 
 import com.joojoo.api.user.application.port.out.file.FilePort;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/AppleClientSecretImpl.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/AppleClientSecretImpl.java
@@ -1,4 +1,4 @@
-package com.joojoo.api.user.infrastructure.social;
+package com.joojoo.api.user.infrastructure.persistence.social;
 
 import com.joojoo.api.user.application.port.out.social.AppleClientSecret;
 import com.joojoo.api.user.presentation.dto.request.apple.AppleTokenResponse;

--- a/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/AppleWebClientSecretImpl.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/AppleWebClientSecretImpl.java
@@ -1,5 +1,6 @@
-package com.joojoo.api.user.application.port.out.social;
+package com.joojoo.api.user.infrastructure.persistence.social;
 
+import com.joojoo.api.user.application.port.out.social.AppleWebClientSecret;
 import com.joojoo.api.user.presentation.dto.request.apple.AppleTokenResponse;
 import com.joojoo.global.exception.handleException.auth.InvalidAuthorizationException;
 import com.joojoo.global.exception.handleException.auth.apple.AppleInvalidTokenResponseException;
@@ -7,11 +8,12 @@ import com.joojoo.global.exception.handleException.auth.apple.AppleTokenIssueFai
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
@@ -23,8 +25,9 @@ import java.util.Base64;
 import java.util.Date;
 
 @Slf4j
-@Component
-public class AppleWeb {
+@Service
+@RequiredArgsConstructor
+public class AppleWebClientSecretImpl implements AppleWebClientSecret {
 
     @Value("${APPLE_TEAM_ID}")
     private String teamId;
@@ -41,7 +44,7 @@ public class AppleWeb {
     @Value("${APPLE_PRIVATE_KEY}")
     private String privateKeyP8;
 
-    // Client Secret 생성
+    @Override
     public String createClientSecret() {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + 3600000); // 1시간 유효
@@ -57,7 +60,7 @@ public class AppleWeb {
                 .compact();
     }
 
-
+    @Override
     public AppleTokenResponse requestAppleToken(String code, String clientSecret) {
         RestClient restClient = RestClient.create();
 
@@ -92,7 +95,6 @@ public class AppleWeb {
         return responseBody;
     }
 
-
     // PrivateKey 객체 생성 헬퍼 (BouncyCastle 라이브러리 필요할 수 있음)
     private PrivateKey getPrivateKey() {
         try {
@@ -110,5 +112,4 @@ public class AppleWeb {
             throw new RuntimeException("Private Key 생성 실패", e);
         }
     }
-
 }

--- a/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/KakaoClientSecretImpl.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/KakaoClientSecretImpl.java
@@ -1,4 +1,4 @@
-package com.joojoo.api.user.infrastructure.social;
+package com.joojoo.api.user.infrastructure.persistence.social;
 
 import com.joojoo.api.user.application.port.out.social.KakaoClientSecret;
 import com.joojoo.api.user.presentation.dto.request.kakao.AccessTokenDto;

--- a/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/withdraw/AppleUnlink.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/withdraw/AppleUnlink.java
@@ -1,5 +1,6 @@
-package com.joojoo.api.user.application.auth.withdraw.out;
+package com.joojoo.api.user.infrastructure.persistence.social.withdraw;
 
+import com.joojoo.api.user.application.port.out.social.SocialUnlink;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.application.port.out.social.AppleClientSecret;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/withdraw/KakaoUnlinkImpl.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/persistence/social/withdraw/KakaoUnlinkImpl.java
@@ -1,5 +1,6 @@
-package com.joojoo.api.user.application.auth.withdraw.out;
+package com.joojoo.api.user.infrastructure.persistence.social.withdraw;
 
+import com.joojoo.api.user.application.port.out.social.SocialUnlink;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.model.enums.Provider;
 import com.joojoo.api.user.application.port.out.social.KakaoClientSecret;

--- a/src/main/java/com/joojoo/api/user/infrastructure/rdbms/UserJpaRepository.java
+++ b/src/main/java/com/joojoo/api/user/infrastructure/rdbms/UserJpaRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserJpaRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByEmail(String email);
-
     Optional<User> findByProviderId(String providerId);
 
     boolean existsUserByName(String name);

--- a/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
+++ b/src/main/java/com/joojoo/api/user/presentation/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.joojoo.api.user.presentation.controller;
 
+import com.joojoo.api.common.domain.request.auth.CustomUserDetails;
+import com.joojoo.api.common.domain.response.BaseResponse;
+import com.joojoo.api.common.domain.response.ErrorResponse;
 import com.joojoo.api.user.application.port.in.*;
 import com.joojoo.api.user.presentation.dto.request.AuthCodeDto;
 import com.joojoo.api.user.presentation.dto.request.AuthTokenDto;
@@ -7,9 +10,6 @@ import com.joojoo.api.user.presentation.dto.request.UpdateProfileDto;
 import com.joojoo.api.user.presentation.dto.response.DefaultProfileImageResponse;
 import com.joojoo.api.user.presentation.dto.response.LoginResponse;
 import com.joojoo.api.user.presentation.dto.response.UserInfoResponse;
-import com.joojoo.api.common.domain.request.auth.CustomUserDetails;
-import com.joojoo.api.common.domain.response.BaseResponse;
-import com.joojoo.api.common.domain.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -76,18 +76,35 @@ public class UserController {
         return BaseResponse.ok(socialLoginUseCase.appleSocialLogin(payload.getCode()));
     }
 
+    @Operation(summary = "안드로이드 애플 로그인 API", description = "안드로이드 애플 로그인 API")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = LoginResponse.class)
+                    )
+            )
+    })
     /** 애플 로그인 웹/안드로이드 */
     @PostMapping(value = "/apple/android/login")
     public BaseResponse<LoginResponse> appleAndroidLogin(@RequestBody AuthCodeDto payload) {
         return BaseResponse.ok(socialLoginUseCase.appleWebLogin(payload.getCode()));
     }
 
+    @Operation(summary = "웹에서 애플 로그인 받아주는 API", description = "웹에서 애플 로그인 후 Code를 받아 앱으로 반화해주는 API")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 권한 변경 성공",
+                    content = @Content(schema = @Schema(implementation = LoginResponse.class)
+                    )
+            )
+    })
     /** 애플 서버로 받은 코드를 앱 서버로 리다력션 */
     @PostMapping(value = "/apple/web/login", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public ResponseEntity<Void> appleWebLogin(AuthCodeDto payload) {
         String intentUrl = socialLoginUseCase.getRedirectUrl(payload.getCode());
 
-        // 307(Temporary Redirect)을 사용하여 앱으로 강제 이동
         return ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT)
                 .location(URI.create(intentUrl))
                 .build();


### PR DESCRIPTION
## 📌 PR 제목

- [Refactor] 회원 탈퇴 도메인 로직 DDD 및 헥사고날 아키텍처 적용

---

## 작업 개요

기존 Layered Architecture 기반의 회원 탈퇴 로직을 **DDD(Domain-Driven Design)**와 **헥사고날 아키텍처** 구조로 리팩토링하여 도메인 중심의 설계와 인프라 유연성을 확보했습니다.

---

## 작업 내용

### 1. 도메인 모델 중심의 상태 관리
- `User` 엔티티 내부에 `withdraw()` 메서드를 정의하여 상태 변경(`WITHDRAWN`) 로직을 캡슐화했습니다.
- 외부에서 직접 필드를 수정하는 방식에서 객체가 스스로 상태를 관리하는 방식으로 변경했습니다.

### 2. Port & Adapter 패턴 적용 (Hexagonal)
- **Inbound Port**: `WithdrawUseCase` 인터페이스를 통해 애플리케이션 진입점을 명확히 정의했습니다.
- **Outbound Port**: `UserPort`, `SocialUnlinkPort`, `TokenPort` 등의 인터페이스를 정의하여 서비스 레이어가 구체적인 기술(JPA, Kakao API 등)에 의존하지 않도록 분리했습니다.
- **Adapters**: `SocialUnlink`를 구현하여 카카오/애플 등 외부 소셜 서비스 해제 로직을 인프라 계층으로 격리했습니다.

---
