### PR TITLE
fix: 숫자/영문 태그 입력 시 500에러 응답 버그 수정

### DIFF
--- a/src/main/java/com/joojoo/api/metadata/application/service/MetadataUseCaseService.java
+++ b/src/main/java/com/joojoo/api/metadata/application/service/MetadataUseCaseService.java
@@ -4,20 +4,23 @@ import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.presentation.dto.request.metadata.MatchedMetadataDto;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.common.domain.enums.TagSourceType;
 import com.joojoo.api.metadata.application.port.in.MetadataUseCase;
 import com.joojoo.api.metadata.application.port.out.MetadataPort;
+import com.joojoo.api.metadata.domain.MetadataContext;
 import com.joojoo.api.metadata.domain.service.MetadataAnalyzer;
 import com.joojoo.api.tag.application.in.TagInService;
 import com.joojoo.api.ticker.application.in.TickerInService;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
-import com.joojoo.api.metadata.domain.MetadataContext;
-import com.joojoo.api.common.domain.enums.TagSourceType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
+++ b/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component
 @RequiredArgsConstructor
@@ -59,11 +60,14 @@ public class MetadataPersistenceAdapter implements MetadataPort { // User 도메
     /** Redis Tag Key 생성 로직 */
     private Set<String> generateLexEntries(Long userId, String name, Long tagId) {
         String base = "*" + name + "*" + tagId;
+        String prefix = userId + ":";
 
-        return Set.of(
-                userId + ":" + hangulConverter.jasoConvert(name) + base,
-                userId + ":" + hangulConverter.chosungConvert(name) + base
-        );
+        return Stream.of(
+                        hangulConverter.jasoConvert(name),
+                        hangulConverter.chosungConvert(name)
+                )
+                .map(converted -> prefix + converted + base)
+                .collect(Collectors.toSet()); // toSet()은 중복이 있어도 에러를 내지 않고 하나로 합칩니다.
     }
 
     @Override


### PR DESCRIPTION
## 📌 PR 제목

- [Fix] 숫자/영문 태그 저장 시 500 에러 수정 및 필터 로직 DDD 리팩토링

---

## 작업 개요

숫자나 영문으로 구성된 태그를 저장할 때 발생하는 서버 응답 오류(500)를 해결하고, 향후 확장성을 위해 필터 관련 쿼리 로직을 DDD(도메인 주도 설계) 구조로 리팩토링했습니다.

---

## 작업 내용

### 1. 버그 수정 (Bug Fix)
- **중복 요소 예외 해결**: `Set.of()`를 사용하여 검색 색인을 생성할 때, 숫자나 영문 태그는 자소/초성 변환 결과가 동일하여 발생하던 `duplicate element` 에러를 수정했습니다.
- **Stream API 적용**: `Collectors.toSet()`을 활용해 중복된 변환 결과가 발생하더라도 예외 없이 안전하게 하나로 합쳐지도록 로직을 개선했습니다.

---

## 관련 이슈

- #65 
