### PR TITLE
feat: TradeLog 삭제 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/block/application/service/command/DeleteBlockService.java
+++ b/src/main/java/com/joojoo/api/block/application/service/command/DeleteBlockService.java
@@ -40,7 +40,6 @@ public class DeleteBlockService implements DeleteBlockUseCase {
         // 삭제 대상 ID 수집 및 관련 태그 백업 (Redis 삭제용)
         List<Long> idsToDelete = blockDomainService.getIdsToDelete(targetBlock, mode);
         List<BlockTag> tagsToRemove = blockTagRepository.findAllByBlockIdIn(idsToDelete);
-        List<BlockTicker> tickersToRemove = blockTickerRepository.findAllTickersByBlockIdIn(idsToDelete);
 
         // 트리 구조 재조정 및 DB 삭제
         if (mode.isAll()) {
@@ -52,7 +51,9 @@ public class DeleteBlockService implements DeleteBlockUseCase {
         if (!tagsToRemove.isEmpty()) {
             metadataPort.processRedisTagRemoval(userId, tagsToRemove);
         }
+
         // 최근 티커 사용할거면 사용 아직, 고도화 전에는 보류
+//        List<BlockTicker> tickersToRemove = blockTickerRepository.findAllTickersByBlockIdIn(idsToDelete);
 //        if (!tickersToRemove.isEmpty()) {
 //            metadataPort.processRedisTickerRemoval(userId, tickersToRemove);
 //        }

--- a/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
@@ -41,4 +41,7 @@ public interface BlockTagRepository {
     /** blockId와 연관된 태그들 조회 */
     List<BlockTag> findAllTagsByBlockId(Long blockId);
 
+    /** TradeLog에 사용된 태그들 삭제 */
+    void deleteByTradeLogId(Long tradeLogId);
+
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/persistence/BlockTagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/persistence/BlockTagRepositoryImpl.java
@@ -80,4 +80,9 @@ public class BlockTagRepositoryImpl implements BlockTagRepository {
         return blockTagQueryDslRepository.findAllTagsByBlockId(blockId);
     }
 
+    @Override
+    public void deleteByTradeLogId(Long tradeLogId) {
+        blockTagQueryDslRepository.deleteByTradeLogId(tradeLogId);
+    }
+
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
@@ -18,4 +18,6 @@ public interface BlockTagQueryDslRepository {
     List<BlockTag> findAllByBlockIdIn(List<Long> blockIds);
 
     List<BlockTag> findAllTagsByBlockId(Long blockId);
+
+    void deleteByTradeLogId(Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
@@ -101,4 +101,11 @@ public class BlockTagQueryDslRepositoryImpl implements BlockTagQueryDslRepositor
                 .where(blockTag.block.id.eq(blockId))
                 .fetch();
     }
+
+    @Override
+    public void deleteByTradeLogId(Long tradeLogId) {
+        queryFactory.delete(blockTag)
+                .where(blockTag.tradeLog.id.eq(tradeLogId))
+                .execute();
+    }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/domain/repository/BlockTickerRepository.java
+++ b/src/main/java/com/joojoo/api/blockTicker/domain/repository/BlockTickerRepository.java
@@ -28,4 +28,7 @@ public interface BlockTickerRepository {
 
     /** 사용자가 최근 사용한 Ticker 10개 조회 */
     List<RecentTickersResponse.RecentTickersDto> findRecentTickers(Long userId);
+
+    /** TradeLog에 사용된 티커들 삭제 */
+    void deleteByTradeLogId(Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepository.java
@@ -15,4 +15,6 @@ public interface BlockTickerQueryDslRepository {
     List<BlockTicker> findAllTickersByBlockIdIn(List<Long> idsToDelete);
 
     List<RecentTickersResponse.RecentTickersDto> findRecentTickers(Long userId);
+
+    void deleteByTradeLogId(Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepositoryImpl.java
@@ -82,4 +82,11 @@ public class BlockTickerQueryDslRepositoryImpl implements BlockTickerQueryDslRep
                 .limit(10)
                 .fetch();
     }
+
+    @Override
+    public void deleteByTradeLogId(Long tradeLogId) {
+        queryFactory.delete(blockTicker)
+                .where(blockTicker.tradeLog.id.eq(tradeLogId))
+                .execute();
+    }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
@@ -59,4 +59,9 @@ public class BlockTickerRepositoryImpl implements BlockTickerRepository {
     public List<RecentTickersResponse.RecentTickersDto> findRecentTickers(Long userId) {
         return blockTickerQueryDslRepository.findRecentTickers(userId);
     }
+
+    @Override
+    public void deleteByTradeLogId(Long tradeLogId) {
+        blockTickerQueryDslRepository.deleteByTradeLogId(tradeLogId);
+    }
 }

--- a/src/main/java/com/joojoo/api/tradeLog/application/port/in/DeleteTradeLogUseCase.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/port/in/DeleteTradeLogUseCase.java
@@ -1,4 +1,5 @@
 package com.joojoo.api.tradeLog.application.port.in;
 
 public interface DeleteTradeLogUseCase {
+    void deleteTradeLog(Long userId, Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/application/service/command/DeleteTradeLogService.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/service/command/DeleteTradeLogService.java
@@ -1,12 +1,39 @@
 package com.joojoo.api.tradeLog.application.service.command;
 
+import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
+import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.metadata.application.port.out.MetadataPort;
 import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
+import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
+import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class DeleteTradeLogService implements DeleteTradeLogUseCase {
 
+    private final TradeLogRepository tradeLogRepository;
+    private final BlockTagRepository blockTagRepository;
+    private final MetadataPort metadataPort;
+
+    @Override
+    @Transactional
+    public void deleteTradeLog(Long userId, Long tradeLogId) {
+        TradeLog tradeLog = tradeLogRepository.getTradeLogById(tradeLogId);
+        // Redis 삭제용
+        List<BlockTag> tagsToRemove = blockTagRepository.findAllTagsByTradeLogIds(Collections.singletonList(tradeLogId));
+
+        // 연관 테이블 일괄 삭제
+        tradeLogRepository.clearMetadataByTradeLog(tradeLogId);
+
+        if (!tagsToRemove.isEmpty()) {
+            metadataPort.processRedisTagRemoval(userId, tagsToRemove);
+        }
+    }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
@@ -8,4 +8,10 @@ public interface TradeLogRepository {
 
     /** TradeLog 회원 삭제 (중간 테이블은 블럭에서 삭제해줌) */
     void withdrawByUserId(Long userId);
+
+    /** 매매일지 조회 */
+    TradeLog getTradeLogById(Long traderLogId);
+
+    /** 매매일지에 사용한 Tags, Tickers 삭제 */
+    void clearMetadataByTradeLog(Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
@@ -2,4 +2,6 @@ package com.joojoo.api.tradeLog.infrastructure.queryDsl;
 
 public interface tradeLogQueryDslRepository {
     void withdrawByUserId(Long userId);
+
+    void deleteByTradeLogId(Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
@@ -19,4 +19,12 @@ public class tradeLogQueryDslRepositoryImpl implements tradeLogQueryDslRepositor
                 .where(tradeLog.user.id.eq(userId))
                 .execute();
     }
+
+    @Override
+    public void deleteByTradeLogId(Long tradeLogId) {
+        queryFactory
+                .delete(tradeLog)
+                .where(tradeLog.id.eq(tradeLogId))
+                .execute();
+    }
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.joojoo.api.tradeLog.infrastructure.rdbms;
 
+import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
+import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import com.joojoo.api.tradeLog.infrastructure.queryDsl.tradeLogQueryDslRepository;
+import com.joojoo.global.exception.handleException.tradeLog.TradeLogNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +15,8 @@ public class TradeLogRepositoryImpl implements TradeLogRepository {
 
     private final TradeLogJpaRepository tradeLogJpaRepository;
     private final tradeLogQueryDslRepository tradeLogQueryDslRepository;
+    private final BlockTagRepository blockTagRepository;
+    private final BlockTickerRepository blockTickerRepository;
 
     @Override
     public TradeLog save(TradeLog tradeLog) {
@@ -22,4 +27,18 @@ public class TradeLogRepositoryImpl implements TradeLogRepository {
     public void withdrawByUserId(Long userId) {
         tradeLogQueryDslRepository.withdrawByUserId(userId);
     }
+
+    @Override
+    public TradeLog getTradeLogById(Long traderLogId) {
+        return tradeLogJpaRepository.findById(traderLogId)
+                .orElseThrow(TradeLogNotFoundException::new);
+    }
+
+    @Override
+    public void clearMetadataByTradeLog(Long tradeLogId) {
+        blockTagRepository.deleteByTradeLogId(tradeLogId);
+        blockTickerRepository.deleteByTradeLogId(tradeLogId);
+        tradeLogQueryDslRepository.deleteByTradeLogId(tradeLogId);
+    }
+
 }

--- a/src/main/java/com/joojoo/api/tradeLog/presentation/controller/TradeLogController.java
+++ b/src/main/java/com/joojoo/api/tradeLog/presentation/controller/TradeLogController.java
@@ -1,6 +1,8 @@
 package com.joojoo.api.tradeLog.presentation.controller;
 
+import com.joojoo.api.block.domain.model.enums.DeleteMode;
 import com.joojoo.api.tradeLog.application.port.in.CreateTradeLogUseCase;
+import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
 import com.joojoo.api.tradeLog.presentation.dto.request.TradeRequestDto;
 import com.joojoo.api.common.domain.request.auth.CustomUserDetails;
 import com.joojoo.api.common.domain.response.BaseResponse;
@@ -14,10 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "TradeLog API", description = "템플릿 관련 API")
 @RestController
@@ -26,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TradeLogController {
 
     private final CreateTradeLogUseCase createTradeLogUseCase;
+    private final DeleteTradeLogUseCase deleteTradeLogUseCase;
 
     @Operation(summary = "템플릿 생성 API", description = "템플릿 작성 API입니다.")
     @ApiResponses({
@@ -52,6 +52,28 @@ public class TradeLogController {
     ) {
         createTradeLogUseCase.createTradesLog(user.getUserId(), tradeRequestDto);
         return BaseResponse.ok("템플릿 작성 성공!");
+    }
+
+    @Operation(summary = "템플릿 삭제 API", description = "템플릿 삭제 API입니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "템플릿 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = String.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 매매일지를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @DeleteMapping("/{tradeLogId}")
+    public BaseResponse<String> deleteBlock(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long tradeLogId
+    ) {
+        deleteTradeLogUseCase.deleteTradeLog(user.getUserId(), tradeLogId);
+        return BaseResponse.ok("템플릿 삭제 성공!");
     }
 
 }

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -62,6 +62,9 @@ public enum ErrorCode {
     INVALID_FILTER_INPUT(400, "INVALID_FILTER_INPUT", "태그 ID 또는 티커 ID 중 하나는 반드시 입력해야 합니다."),
     DUPLICATE_FILTER_INPUT(400, "DUPLICATE_FILTER_INPUT", "태그 ID와 티커 ID는 동시에 입력할 수 없습니다."),
 
+    //---------------------------- 매매일지 (TradeLog) ----------------------------
+    TRADE_LOG_NOT_FOUND(404, "TRADE_LOG_NOT_FOUND", "해당 매매일지를 찾을 수 없습니다."),
+
     ;
 
     private final int httpStatus;

--- a/src/main/java/com/joojoo/global/exception/handleException/tradeLog/TradeLogNotFoundException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/tradeLog/TradeLogNotFoundException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.tradeLog;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class TradeLogNotFoundException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.TRADE_LOG_NOT_FOUND;
+
+    public TradeLogNotFoundException() {
+        super(errorCode);
+    }
+
+    public TradeLogNotFoundException(Exception exception) {
+        super(errorCode, exception);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] TradeLog 매매일지 삭제 API 구현 

---

## 작업 개요

사용자의 **매매일지(TradeLog)**를 삭제하는 기능을 구현하였습니다. 삭제 시 매매일지에 종속된 **태그(BlockTag)**와 **티커(BlockTicker)** 데이터를 무결하게 정리하며, Redis에 저장된 자동완성용 태그 메타데이터까지 함께 동기화하도록 처리했습니다.

---

## 작업 내용

### 1. 매매일지 삭제 유스케이스 구현
- **Application Layer**: `TradeLogService` 내 삭제 로직을 구현하여 비즈니스 흐름을 제어합니다.
- **연관 데이터 정리**: 매매일지 삭제 전, Redis 자동완성 데이터 삭제를 위해 기존 태그 목록을 먼저 확보한 뒤 일괄 삭제 프로세스를 진행합니다.

### 2. Infrastructure Layer 최적화 (Bulk Delete)
- **벌크 삭제 적용**: `deleteByTradeLogId` 메서드를 통해 자식 테이블(BlockTag, BlockTicker)의 데이터를 `N+1` 문제 없이 단일 쿼리로 대량 삭제합니다.
- **영속성 컨텍스트 관리**: 벌크 삭제 후 DB와 영속성 컨텍스트 간의 불일치로 인한 `TransientPropertyValueException`을 방지하기 위해 `flush` 및 `clear` 처리를 적용하여 안정성을 확보했습니다.

### 3. 헥사고날 아키텍처 및 의존성 설계
- **재사용성**: 매매일지 관련 메타데이터를 한 번에 정리하는 `clearMetadataByTradeLog` 로직을 인프라 어댑터에 응집시켜 관리 효율을 높였습니다.

---
