### PR TITLE
refactor: TradeLog 삭제 API 예외 처리 구현

### DIFF
--- a/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/domain/repository/BlockTagRepository.java
@@ -42,6 +42,6 @@ public interface BlockTagRepository {
     List<BlockTag> findAllTagsByBlockId(Long blockId);
 
     /** TradeLog에 사용된 태그들 삭제 */
-    void deleteByTradeLogId(Long tradeLogId);
+    void deleteByTradeLogId(Long userId, Long tradeLogId);
 
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/persistence/BlockTagRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/persistence/BlockTagRepositoryImpl.java
@@ -81,8 +81,8 @@ public class BlockTagRepositoryImpl implements BlockTagRepository {
     }
 
     @Override
-    public void deleteByTradeLogId(Long tradeLogId) {
-        blockTagQueryDslRepository.deleteByTradeLogId(tradeLogId);
+    public void deleteByTradeLogId(Long userId, Long tradeLogId) {
+        blockTagQueryDslRepository.deleteByTradeLogId(userId, tradeLogId);
     }
 
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepository.java
@@ -19,5 +19,5 @@ public interface BlockTagQueryDslRepository {
 
     List<BlockTag> findAllTagsByBlockId(Long blockId);
 
-    void deleteByTradeLogId(Long tradeLogId);
+    void deleteByTradeLogId(Long userId, Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTag/infrastructure/queryDsl/BlockTagQueryDslRepositoryImpl.java
@@ -103,9 +103,12 @@ public class BlockTagQueryDslRepositoryImpl implements BlockTagQueryDslRepositor
     }
 
     @Override
-    public void deleteByTradeLogId(Long tradeLogId) {
+    public void deleteByTradeLogId(Long userId, Long tradeLogId) {
         queryFactory.delete(blockTag)
-                .where(blockTag.tradeLog.id.eq(tradeLogId))
+                .where(
+                        blockTag.userId.eq(userId),
+                        blockTag.tradeLog.id.eq(tradeLogId)
+                )
                 .execute();
     }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/domain/repository/BlockTickerRepository.java
+++ b/src/main/java/com/joojoo/api/blockTicker/domain/repository/BlockTickerRepository.java
@@ -30,5 +30,5 @@ public interface BlockTickerRepository {
     List<RecentTickersResponse.RecentTickersDto> findRecentTickers(Long userId);
 
     /** TradeLog에 사용된 티커들 삭제 */
-    void deleteByTradeLogId(Long tradeLogId);
+    void deleteByTradeLogId(Long userId, Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepository.java
@@ -16,5 +16,5 @@ public interface BlockTickerQueryDslRepository {
 
     List<RecentTickersResponse.RecentTickersDto> findRecentTickers(Long userId);
 
-    void deleteByTradeLogId(Long tradeLogId);
+    void deleteByTradeLogId(Long userId, Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/queryDsl/BlockTickerQueryDslRepositoryImpl.java
@@ -84,9 +84,12 @@ public class BlockTickerQueryDslRepositoryImpl implements BlockTickerQueryDslRep
     }
 
     @Override
-    public void deleteByTradeLogId(Long tradeLogId) {
+    public void deleteByTradeLogId(Long userId, Long tradeLogId) {
         queryFactory.delete(blockTicker)
-                .where(blockTicker.tradeLog.id.eq(tradeLogId))
+                .where(
+                        blockTicker.userId.eq(userId),
+                        blockTicker.tradeLog.id.eq(tradeLogId)
+                )
                 .execute();
     }
 }

--- a/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/blockTicker/infrastructure/rdbms/BlockTickerRepositoryImpl.java
@@ -61,7 +61,7 @@ public class BlockTickerRepositoryImpl implements BlockTickerRepository {
     }
 
     @Override
-    public void deleteByTradeLogId(Long tradeLogId) {
-        blockTickerQueryDslRepository.deleteByTradeLogId(tradeLogId);
+    public void deleteByTradeLogId(Long userId, Long tradeLogId) {
+        blockTickerQueryDslRepository.deleteByTradeLogId(userId, tradeLogId);
     }
 }

--- a/src/main/java/com/joojoo/api/tradeLog/application/service/command/DeleteTradeLogService.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/service/command/DeleteTradeLogService.java
@@ -25,11 +25,13 @@ public class DeleteTradeLogService implements DeleteTradeLogUseCase {
     @Transactional
     public void deleteTradeLog(Long userId, Long tradeLogId) {
         TradeLog tradeLog = tradeLogRepository.getTradeLogById(tradeLogId);
+        tradeLog.validateOwner(userId);
+
         // Redis 삭제용
         List<BlockTag> tagsToRemove = blockTagRepository.findAllTagsByTradeLogIds(Collections.singletonList(tradeLogId));
 
         // 연관 테이블 일괄 삭제
-        tradeLogRepository.clearMetadataByTradeLog(tradeLogId);
+        tradeLogRepository.clearMetadataByTradeLog(userId, tradeLogId);
 
         if (!tagsToRemove.isEmpty()) {
             metadataPort.processRedisTagRemoval(userId, tagsToRemove);

--- a/src/main/java/com/joojoo/api/tradeLog/domain/model/entity/TradeLog.java
+++ b/src/main/java/com/joojoo/api/tradeLog/domain/model/entity/TradeLog.java
@@ -6,6 +6,7 @@ import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.common.domain.entity.BaseTimeEntity;
 import com.joojoo.api.common.domain.enums.TagSourceType;
 import com.joojoo.api.common.domain.enums.TradeType;
+import com.joojoo.global.exception.handleException.tradeLog.NotTradeLogOwnerException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -95,6 +96,12 @@ public class TradeLog extends BaseTimeEntity {
                 TagSourceType.TRADE_RISK, Objects.requireNonNullElse(this.riskFactor, ""),
                 TagSourceType.TRADE_PLAN, Objects.requireNonNullElse(this.tradingPlan, "")
         );
+    }
+
+    public void validateOwner(Long userId) {
+        if (!this.user.getId().equals(userId)) {
+            throw new NotTradeLogOwnerException();
+        }
     }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
@@ -13,5 +13,5 @@ public interface TradeLogRepository {
     TradeLog getTradeLogById(Long traderLogId);
 
     /** 매매일지에 사용한 Tags, Tickers 삭제 */
-    void clearMetadataByTradeLog(Long tradeLogId);
+    void clearMetadataByTradeLog(Long userId, Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
@@ -3,5 +3,5 @@ package com.joojoo.api.tradeLog.infrastructure.queryDsl;
 public interface tradeLogQueryDslRepository {
     void withdrawByUserId(Long userId);
 
-    void deleteByTradeLogId(Long tradeLogId);
+    void deleteByTradeLogId(Long userId, Long tradeLogId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
@@ -21,10 +21,13 @@ public class tradeLogQueryDslRepositoryImpl implements tradeLogQueryDslRepositor
     }
 
     @Override
-    public void deleteByTradeLogId(Long tradeLogId) {
+    public void deleteByTradeLogId(Long userId, Long tradeLogId) {
         queryFactory
                 .delete(tradeLog)
-                .where(tradeLog.id.eq(tradeLogId))
+                .where(
+                        tradeLog.user.id.eq(userId),
+                        tradeLog.id.eq(tradeLogId)
+                )
                 .execute();
     }
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
@@ -35,10 +35,10 @@ public class TradeLogRepositoryImpl implements TradeLogRepository {
     }
 
     @Override
-    public void clearMetadataByTradeLog(Long tradeLogId) {
-        blockTagRepository.deleteByTradeLogId(tradeLogId);
-        blockTickerRepository.deleteByTradeLogId(tradeLogId);
-        tradeLogQueryDslRepository.deleteByTradeLogId(tradeLogId);
+    public void clearMetadataByTradeLog(Long userId, Long tradeLogId) {
+        blockTagRepository.deleteByTradeLogId(userId, tradeLogId);
+        blockTickerRepository.deleteByTradeLogId(userId, tradeLogId);
+        tradeLogQueryDslRepository.deleteByTradeLogId(userId, tradeLogId);
     }
 
 }

--- a/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/joojoo/global/exception/enums/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
 
     //---------------------------- 매매일지 (TradeLog) ----------------------------
     TRADE_LOG_NOT_FOUND(404, "TRADE_LOG_NOT_FOUND", "해당 매매일지를 찾을 수 없습니다."),
+    TRADE_LOG_OWNER_FOUND(403, "TRADE_LOG_OWNER_FOUND", "해당 매매일지 작성자만 삭제 할 수 있습니다."),
 
     ;
 

--- a/src/main/java/com/joojoo/global/exception/handleException/tradeLog/NotTradeLogOwnerException.java
+++ b/src/main/java/com/joojoo/global/exception/handleException/tradeLog/NotTradeLogOwnerException.java
@@ -1,0 +1,16 @@
+package com.joojoo.global.exception.handleException.tradeLog;
+
+import com.joojoo.global.exception.ServiceException;
+import com.joojoo.global.exception.enums.ErrorCode;
+
+public class NotTradeLogOwnerException extends ServiceException {
+    private static final ErrorCode errorCode = ErrorCode.TRADE_LOG_OWNER_FOUND;
+
+    public NotTradeLogOwnerException() {
+        super(errorCode);
+    }
+
+    public NotTradeLogOwnerException(Exception exception) {
+        super(errorCode, exception);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 매매일지 삭제 시 소유권 검증 로직 및 예외 처리 추가

---

## 작업 개요

매매일지 삭제 시 본인의 데이터만 삭제할 수 있도록 소유권 검증(Owner Validation) 기능을 추가하고, 인프라 계층에서 발생할 수 있는 예외 상황에 대한 방어 로직을 구현했습니다.

---

## 작업 내용

### 1. 도메인 기반 권한 검증 도입
- **Domain Layer**: `TradeLog` 엔티티 내에 `validateOwner(userId)` 메서드를 추가하여 비즈니스 규칙(소유권 확인)을 도메인 모델 내부로 응집시켰습니다.
- **Application Layer**: 삭제 유스케이스 실행 전, 조회된 `TradeLog` 객체를 통해 권한을 먼저 검증하도록 흐름을 개선했습니다.

### 2. Infrastructure Layer 방어적 설계
- **이중 검증**: `clearMetadataByTradeLog` 메서드의 삭제 쿼리에 `userId` 조건을 추가하여 인프라 수준에서 보안을 강화했습니다.

---
