### PR TITLE
feat: TradeLog 주식 거래 지표 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/ticker/domain/repository/TickerRepository.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/repository/TickerRepository.java
@@ -17,4 +17,7 @@ public interface TickerRepository {
 
     /** Ticker 프록시 객체 반환 */
     Ticker getReferenceById(Long tickerId);
+
+    /** Ticker 존재 여부 확인 */
+    boolean existsById(Long tickerId);
 }

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/persistence/TickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/persistence/TickerRepositoryImpl.java
@@ -52,6 +52,11 @@ public class TickerRepositoryImpl implements TickerRepository, TickerInService {
     }
 
     @Override
+    public boolean existsById(Long tickerId) {
+        return tickerJpaRepository.existsById(tickerId);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public Map<String, Ticker> getTickerMap(Set<String> names) {
         if (names.isEmpty()) return Collections.emptyMap();

--- a/src/main/java/com/joojoo/api/tradeLog/application/port/in/GetTraderLogUseCase.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/port/in/GetTraderLogUseCase.java
@@ -1,0 +1,8 @@
+package com.joojoo.api.tradeLog.application.port.in;
+
+import com.joojoo.api.tradeLog.presentation.dto.request.calculate.TradeCalculateRequest;
+import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
+
+public interface GetTraderLogUseCase {
+    TradeMetricsResponse getTradeLogCalculate(Long userId, TradeCalculateRequest tradeCalculateRequest);
+}

--- a/src/main/java/com/joojoo/api/tradeLog/application/service/query/QueryTraderLogService.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/service/query/QueryTraderLogService.java
@@ -1,0 +1,36 @@
+package com.joojoo.api.tradeLog.application.service.query;
+
+import com.joojoo.api.ticker.domain.repository.TickerRepository;
+import com.joojoo.api.tradeLog.application.port.in.GetTraderLogUseCase;
+import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
+import com.joojoo.api.tradeLog.presentation.dto.request.calculate.TradeCalculateRequest;
+import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
+import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
+import com.joojoo.global.exception.handleException.tickers.TickerNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class QueryTraderLogService implements GetTraderLogUseCase {
+
+    private final TradeLogRepository tradeLogRepository;
+    private final TickerRepository tickerRepository;
+
+    @Override
+    public TradeMetricsResponse getTradeLogCalculate(Long userId, TradeCalculateRequest tradeCalculateRequest) {
+        if(!tickerRepository.existsById(tradeCalculateRequest.getTickerId())){
+            throw new TickerNotFoundException();
+        }
+
+        TradeMetrics metrics = tradeLogRepository.findAllBuyLogsByTicker(userId, tradeCalculateRequest.getTickerId());
+        if (metrics == null || metrics.getCurrentQuantity().compareTo(BigDecimal.ZERO) <= 0) {
+            return TradeMetricsResponse.empty();
+        }
+
+        return metrics.calculate(tradeCalculateRequest.getCurrentPrice());
+    }
+
+}

--- a/src/main/java/com/joojoo/api/tradeLog/application/service/query/QueryTraderLogService.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/service/query/QueryTraderLogService.java
@@ -4,7 +4,7 @@ import com.joojoo.api.ticker.domain.repository.TickerRepository;
 import com.joojoo.api.tradeLog.application.port.in.GetTraderLogUseCase;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import com.joojoo.api.tradeLog.presentation.dto.request.calculate.TradeCalculateRequest;
-import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
+import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
 import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
 import com.joojoo.global.exception.handleException.tickers.TickerNotFoundException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.tradeLog.domain.repository;
 
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
+import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
 
 public interface TradeLogRepository {
     /** TradeLog 저장 */
@@ -14,4 +15,7 @@ public interface TradeLogRepository {
 
     /** 매매일지에 사용한 Tags, Tickers 삭제 */
     void clearMetadataByTradeLog(Long userId, Long tradeLogId);
+
+    /** 사용자가 특정 종목을 매수한 기록을 조회 */
+    TradeMetrics findAllBuyLogsByTicker(Long userId, Long tickerId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
@@ -1,7 +1,7 @@
 package com.joojoo.api.tradeLog.domain.repository;
 
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
-import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
+import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
 
 public interface TradeLogRepository {
     /** TradeLog 저장 */

--- a/src/main/java/com/joojoo/api/tradeLog/domain/service/TradeMetrics.java
+++ b/src/main/java/com/joojoo/api/tradeLog/domain/service/TradeMetrics.java
@@ -1,0 +1,73 @@
+package com.joojoo.api.tradeLog.domain.service;
+
+import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Slf4j
+@Getter
+@NoArgsConstructor
+public class TradeMetrics {
+    private BigDecimal currentQuantity;     // 현재 보유 수량 (매수합 - 매도합)
+    private BigDecimal totalPurchaseAmount; // 보유 중인 주식의 총 매수 원가
+    private BigDecimal averagePrice;        // 평균 매수가
+
+    private BigDecimal calculateAveragePrice(BigDecimal buyQty, BigDecimal buyAmount) {
+        if (buyQty == null || buyQty.compareTo(BigDecimal.ZERO) <= 0) return BigDecimal.ZERO;
+        return buyAmount.divide(buyQty, 2, RoundingMode.HALF_UP);
+    }
+
+    public TradeMetrics(BigDecimal totalBuyQty, BigDecimal totalSellQty, BigDecimal totalBuyAmount) {
+        // 현재 보유 수량 계산
+        BigDecimal buyQty = totalBuyQty != null ? totalBuyQty : BigDecimal.ZERO;
+        BigDecimal sellQty = totalSellQty != null ? totalSellQty : BigDecimal.ZERO;
+
+        this.currentQuantity = buyQty.subtract(sellQty);
+
+        // 총 매수 원가 (평단가 계산용)
+        this.totalPurchaseAmount = totalBuyAmount != null ? totalBuyAmount : BigDecimal.ZERO;
+
+        // 평균 매수가 계산
+        this.averagePrice = calculateAveragePrice(buyQty, totalBuyAmount);
+    }
+
+    public TradeMetricsResponse calculate(BigDecimal currentPrice) {
+        if (currentPrice == null) return TradeMetricsResponse.empty();
+
+        BigDecimal evaluationAmount = calculateEvaluationAmount(currentPrice);  // 평가 금액
+        BigDecimal investedAmount = calculateInvestedAmount();                  // 투자 원가 계산
+        BigDecimal profitLoss = calculateProfitLoss(evaluationAmount, investedAmount); // 손익
+        BigDecimal yield = calculateYield(profitLoss, investedAmount);          // 수익률
+
+        return TradeMetricsResponse.of(this.currentQuantity, this.averagePrice, profitLoss, yield);
+    }
+
+    // 평가 금액 계산: 현재가 * 보유 수량
+    private BigDecimal calculateEvaluationAmount(BigDecimal currentPrice) {
+        return currentPrice.multiply(this.currentQuantity);
+    }
+
+    // 실제 투자 원가 계산: 평균 매수가 * 현재 보유 수량
+    private BigDecimal calculateInvestedAmount() {
+        return this.averagePrice.multiply(this.currentQuantity);
+    }
+
+    // 평가 손익 계산: 평가 금액 - 투자 원가
+    private BigDecimal calculateProfitLoss(BigDecimal evaluationAmount, BigDecimal investedAmount) {
+        return evaluationAmount.subtract(investedAmount);
+    }
+
+    // 수익률 계산: (손익 / 원가) * 100
+    private BigDecimal calculateYield(BigDecimal profitLoss, BigDecimal investedAmount) {
+        if (investedAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO;
+        }
+        return profitLoss.divide(investedAmount, 4, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"));
+    }
+
+}

--- a/src/main/java/com/joojoo/api/tradeLog/domain/service/calculate/TradeMetrics.java
+++ b/src/main/java/com/joojoo/api/tradeLog/domain/service/calculate/TradeMetrics.java
@@ -1,4 +1,4 @@
-package com.joojoo.api.tradeLog.domain.service;
+package com.joojoo.api.tradeLog.domain.service.calculate;
 
 import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
 import lombok.Getter;

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
@@ -1,7 +1,11 @@
 package com.joojoo.api.tradeLog.infrastructure.queryDsl;
 
+import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
+
 public interface tradeLogQueryDslRepository {
     void withdrawByUserId(Long userId);
 
     void deleteByTradeLogId(Long userId, Long tradeLogId);
+
+    TradeMetrics findAllBuyLogsByTicker(Long userId, Long tickerId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
@@ -1,6 +1,6 @@
 package com.joojoo.api.tradeLog.infrastructure.queryDsl;
 
-import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
+import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
 
 public interface tradeLogQueryDslRepository {
     void withdrawByUserId(Long userId);

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.joojoo.api.tradeLog.infrastructure.queryDsl;
 
 import com.joojoo.api.common.domain.enums.TradeType;
 import com.joojoo.api.tradeLog.domain.model.entity.QTradeLog;
-import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
+import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
@@ -1,9 +1,15 @@
 package com.joojoo.api.tradeLog.infrastructure.queryDsl;
 
+import com.joojoo.api.common.domain.enums.TradeType;
 import com.joojoo.api.tradeLog.domain.model.entity.QTradeLog;
+import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
 
 @Repository
 @RequiredArgsConstructor
@@ -30,4 +36,37 @@ public class tradeLogQueryDslRepositoryImpl implements tradeLogQueryDslRepositor
                 )
                 .execute();
     }
+
+    @Override
+    public TradeMetrics findAllBuyLogsByTicker(Long userId, Long tickerId) {
+        CaseBuilder caseBuilder = new CaseBuilder();
+
+        return queryFactory
+                .select(Projections.constructor(TradeMetrics.class,
+                        // 매수 수량 합계: BUY일 때만 amount, 아니면 0
+                        caseBuilder.when(tradeLog.tradeType.eq(TradeType.BUY))
+                                .then(tradeLog.amount)
+                                .otherwise(BigDecimal.ZERO)
+                                .sum(),
+
+                        // 매도 수량 합계: SELL일 때만 amount, 아니면 0
+                        caseBuilder.when(tradeLog.tradeType.eq(TradeType.SELL))
+                                .then(tradeLog.amount)
+                                .otherwise(BigDecimal.ZERO)
+                                .sum(),
+
+                        // 총 매수 금액 합계: BUY일 때만 (가격 * 수량), 아니면 0
+                        caseBuilder.when(tradeLog.tradeType.eq(TradeType.BUY))
+                                .then(tradeLog.price.multiply(tradeLog.amount))
+                                .otherwise(BigDecimal.ZERO)
+                                .sum()
+                ))
+                .from(tradeLog)
+                .where(
+                        tradeLog.user.id.eq(userId),
+                        tradeLog.ticker.id.eq(tickerId)
+                )
+                .fetchOne();
+    }
+
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import com.joojoo.api.tradeLog.infrastructure.queryDsl.tradeLogQueryDslRepository;
+import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
 import com.joojoo.global.exception.handleException.tradeLog.TradeLogNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -39,6 +40,11 @@ public class TradeLogRepositoryImpl implements TradeLogRepository {
         blockTagRepository.deleteByTradeLogId(userId, tradeLogId);
         blockTickerRepository.deleteByTradeLogId(userId, tradeLogId);
         tradeLogQueryDslRepository.deleteByTradeLogId(userId, tradeLogId);
+    }
+
+    @Override
+    public TradeMetrics findAllBuyLogsByTicker(Long userId, Long tickerId) {
+        return tradeLogQueryDslRepository.findAllBuyLogsByTicker(userId, tickerId);
     }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
@@ -5,7 +5,7 @@ import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import com.joojoo.api.tradeLog.infrastructure.queryDsl.tradeLogQueryDslRepository;
-import com.joojoo.api.tradeLog.domain.service.TradeMetrics;
+import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
 import com.joojoo.global.exception.handleException.tradeLog.TradeLogNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/joojoo/api/tradeLog/presentation/controller/TradeLogController.java
+++ b/src/main/java/com/joojoo/api/tradeLog/presentation/controller/TradeLogController.java
@@ -1,12 +1,14 @@
 package com.joojoo.api.tradeLog.presentation.controller;
 
-import com.joojoo.api.block.domain.model.enums.DeleteMode;
-import com.joojoo.api.tradeLog.application.port.in.CreateTradeLogUseCase;
-import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
-import com.joojoo.api.tradeLog.presentation.dto.request.TradeRequestDto;
 import com.joojoo.api.common.domain.request.auth.CustomUserDetails;
 import com.joojoo.api.common.domain.response.BaseResponse;
 import com.joojoo.api.common.domain.response.ErrorResponse;
+import com.joojoo.api.tradeLog.application.port.in.CreateTradeLogUseCase;
+import com.joojoo.api.tradeLog.application.port.in.DeleteTradeLogUseCase;
+import com.joojoo.api.tradeLog.application.port.in.GetTraderLogUseCase;
+import com.joojoo.api.tradeLog.presentation.dto.request.TradeRequestDto;
+import com.joojoo.api.tradeLog.presentation.dto.request.calculate.TradeCalculateRequest;
+import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/trades")
 public class TradeLogController {
 
+    private final GetTraderLogUseCase getTraderLogUseCase;
     private final CreateTradeLogUseCase createTradeLogUseCase;
     private final DeleteTradeLogUseCase deleteTradeLogUseCase;
 
@@ -74,6 +77,27 @@ public class TradeLogController {
     ) {
         deleteTradeLogUseCase.deleteTradeLog(user.getUserId(), tradeLogId);
         return BaseResponse.ok("템플릿 삭제 성공!");
+    }
+
+    @Operation(summary = "템플릿 거래 정보 API", description = "템플릿 거래 정보 API입니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = TradeMetricsResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 매매일지를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/calculate")
+    public BaseResponse<TradeMetricsResponse> getTradeLogCalculate(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Valid @RequestBody TradeCalculateRequest tradeCalculateRequest
+            ) {
+        return BaseResponse.ok(getTraderLogUseCase.getTradeLogCalculate(user.getUserId(), tradeCalculateRequest));
     }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/presentation/dto/request/calculate/TradeCalculateRequest.java
+++ b/src/main/java/com/joojoo/api/tradeLog/presentation/dto/request/calculate/TradeCalculateRequest.java
@@ -1,0 +1,21 @@
+package com.joojoo.api.tradeLog.presentation.dto.request.calculate;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class TradeCalculateRequest {
+    @NotNull(message = "대상 종목(Ticker) 정보는 필수입니다.")
+    private Long tickerId;
+
+    @NotNull(message = "현재가는 필수입니다.")
+    @DecimalMin(value = "0.0", inclusive = false, message = "현재가는 0보다 커야 합니다.")
+    @Digits(integer = 12, fraction = 4, message = "현재가는 정수 12자리, 소수점 4자리 이내여야 합니다.")
+    private BigDecimal currentPrice;
+}

--- a/src/main/java/com/joojoo/api/tradeLog/presentation/dto/response/calculate/TradeMetricsResponse.java
+++ b/src/main/java/com/joojoo/api/tradeLog/presentation/dto/response/calculate/TradeMetricsResponse.java
@@ -1,0 +1,35 @@
+package com.joojoo.api.tradeLog.presentation.dto.response.calculate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Slf4j
+@Builder
+@Getter
+@AllArgsConstructor
+public class TradeMetricsResponse {
+    private String currentQuantity; // 현재 보유 수량
+    private String averagePrice;    // 평균 매수가
+    private String profitLoss;      // 평가 손익
+    private String yield;           // 수익률 (%)
+
+    public static TradeMetricsResponse empty() {
+        return new TradeMetricsResponse("0", "0", "0", "0");
+    }
+
+    public static TradeMetricsResponse of(BigDecimal currentQuantity, BigDecimal averagePrice, BigDecimal profitLoss, BigDecimal yield){
+        return TradeMetricsResponse.builder()
+                .currentQuantity(currentQuantity.stripTrailingZeros().toPlainString())
+                .averagePrice(averagePrice.stripTrailingZeros().toPlainString())
+                .profitLoss(profitLoss.stripTrailingZeros().toPlainString())
+                .yield(yield.setScale(2, RoundingMode.HALF_UP).stripTrailingZeros().toPlainString())
+                .build();
+    }
+
+}

--- a/src/test/java/com/joojoo/api/tradeLog/domain/service/calculate/TradeMetricsTest.java
+++ b/src/test/java/com/joojoo/api/tradeLog/domain/service/calculate/TradeMetricsTest.java
@@ -1,0 +1,225 @@
+package com.joojoo.api.tradeLog.domain.service.calculate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TradeMetricsTest {
+
+    @Test
+    @DisplayName("평가 금액 계산: 현재가와 보유 수량을 곱한 값이 정확해야 한다")
+    void calculateEvaluationAmount_success() {
+        // given
+        // 10.5주를 보유하고 있고 현재가가 10,000원인 상황
+        BigDecimal currentQuantity = new BigDecimal("10.5");
+        BigDecimal currentPrice = new BigDecimal("10000");
+
+        // when
+        BigDecimal result = currentPrice.multiply(currentQuantity);
+
+        // then
+        // 10,000 * 10.5 = 105,000
+        assertThat(result).isEqualByComparingTo("105000");
+    }
+
+    @Test
+    @DisplayName("평가 금액 계산: 현재가가 0원인 경우 평가 금액은 0원이어야 한다")
+    void calculateEvaluationAmount_when_price_is_zero() {
+        // given
+        BigDecimal currentQuantity = new BigDecimal("50");
+        BigDecimal currentPrice = BigDecimal.ZERO;
+
+        // when
+        BigDecimal result = currentPrice.multiply(currentQuantity);
+
+        // then
+        assertThat(result).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("평가 금액 계산: 소수점 단위의 수량과 현재가 계산이 정확해야 한다")
+    void calculateEvaluationAmount_with_decimal_points() {
+        // given
+        // 0.1234주 보유, 현재가 1,234,567원
+        BigDecimal currentQuantity = new BigDecimal("0.1234");
+        BigDecimal currentPrice = new BigDecimal("1234567");
+
+        // when
+        BigDecimal result = currentPrice.multiply(currentQuantity);
+
+        // then
+        // 1,234,567 * 0.1234 = 152345.5678
+        assertThat(result).isEqualByComparingTo("152345.5678");
+    }
+
+    @Test
+    @DisplayName("투자 원가 계산: 평균 매수가와 현재 보유 수량을 곱한 값이 정확해야 한다")
+    void calculateInvestedAmount_success() {
+        // given
+        // 평단가 55,000원에 10주를 보유하고 있는 상황
+        BigDecimal averagePrice = new BigDecimal("55000");
+        BigDecimal currentQuantity = new BigDecimal("10");
+
+        // when
+        // 원가 = 55,000 * 10
+        BigDecimal result = averagePrice.multiply(currentQuantity);
+
+        // then
+        assertThat(result).isEqualByComparingTo("550000");
+    }
+
+    @Test
+    @DisplayName("투자 원가 계산: 소수점 단위의 수량을 보유한 경우에도 원가가 정확히 계산되어야 한다")
+    void calculateInvestedAmount_with_decimal_quantity() {
+        // given
+        // 평단가 1,200.5원, 보유 수량 0.5주
+        BigDecimal averagePrice = new BigDecimal("1200.5");
+        BigDecimal currentQuantity = new BigDecimal("0.5");
+
+        // when
+        // 원가 = 1200.5 * 0.5 = 600.25
+        BigDecimal result = averagePrice.multiply(currentQuantity);
+
+        // then
+        assertThat(result).isEqualByComparingTo("600.25");
+    }
+
+    @Test
+    @DisplayName("투자 원가 계산: 보유 수량이 0인 경우 투자 원가는 0원이어야 한다")
+    void calculateInvestedAmount_when_quantity_is_zero() {
+        // given
+        BigDecimal averagePrice = new BigDecimal("100000");
+        BigDecimal currentQuantity = BigDecimal.ZERO;
+
+        // when
+        BigDecimal result = averagePrice.multiply(currentQuantity);
+
+        // then
+        assertThat(result).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("평가 손익 계산: 평가 금액이 투자 원가보다 클 때 이익이 정확히 계산되어야 한다")
+    void calculateProfitLoss_profit() {
+        // given
+        // 평가 금액: 1,575,000원, 투자 원가: 1,501,500원
+        BigDecimal evaluationAmount = new BigDecimal("1575000");
+        BigDecimal investedAmount = new BigDecimal("1501500");
+
+        // when
+        // 손익 = 1,575,000 - 1,501,500 = 73,500
+        BigDecimal result = evaluationAmount.subtract(investedAmount);
+
+        // then
+        assertThat(result).isEqualByComparingTo("73500");
+    }
+
+    @Test
+    @DisplayName("평가 손익 계산: 평가 금액이 투자 원가보다 작을 때 손실액이 마이너스로 정확히 계산되어야 한다")
+    void calculateProfitLoss_loss() {
+        // given
+        // 평가 금액: 80,000원, 투자 원가: 100,000원
+        BigDecimal evaluationAmount = new BigDecimal("80000");
+        BigDecimal investedAmount = new BigDecimal("100000");
+
+        // when
+        // 손익 = 80,000 - 100,000 = -20,000
+        BigDecimal result = evaluationAmount.subtract(investedAmount);
+
+        // then
+        assertThat(result).isEqualByComparingTo("-20000");
+    }
+
+    @Test
+    @DisplayName("평가 손익 계산: 소수점이 포함된 금액들 간의 차이도 정확하게 계산되어야 한다")
+    void calculateProfitLoss_with_decimal() {
+        // given
+        // 평가 금액: 1000.555, 투자 원가: 1000.111
+        BigDecimal evaluationAmount = new BigDecimal("1000.555");
+        BigDecimal investedAmount = new BigDecimal("1000.111");
+
+        // when
+        // 손익 = 0.444
+        BigDecimal result = evaluationAmount.subtract(investedAmount);
+
+        // then
+        assertThat(result).isEqualByComparingTo("0.444");
+    }
+
+    @Test
+    @DisplayName("수익률 계산: 이익이 발생했을 때 수익률이 정확하게 계산되어야 한다")
+    void calculateYield_profit() {
+        // given
+        // 손익: 5,000원, 투자 원가: 100,000원
+        BigDecimal profitLoss = new BigDecimal("5000");
+        BigDecimal investedAmount = new BigDecimal("100000");
+
+        // when
+        // (5,000 / 100,000) * 100 = 5.0000
+        BigDecimal result = profitLoss.divide(investedAmount, 4, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"));
+
+        // then
+        assertThat(result).isEqualByComparingTo("5");
+    }
+
+    @Test
+    @DisplayName("수익률 계산: 손실이 발생했을 때 마이너스 수익률이 정확하게 계산되어야 한다")
+    void calculateYield_loss() {
+        // given
+        // 손익: -2,000원, 투자 원가: 10,000원
+        BigDecimal profitLoss = new BigDecimal("-2000");
+        BigDecimal investedAmount = new BigDecimal("10000");
+
+        // when
+        // (-2,000 / 10,000) * 100 = -20.0000
+        BigDecimal result = profitLoss.divide(investedAmount, 4, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"));
+
+        // then
+        assertThat(result).isEqualByComparingTo("-20");
+    }
+
+    @Test
+    @DisplayName("수익률 계산: 투자 원가가 0이거나 음수인 경우 수익률은 0이어야 한다")
+    void calculateYield_when_investedAmount_is_zero() {
+        // given
+        BigDecimal profitLoss = new BigDecimal("5000");
+        BigDecimal investedAmount = BigDecimal.ZERO;
+
+        // when
+        BigDecimal result;
+        if (investedAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            result = BigDecimal.ZERO;
+        } else {
+            result = profitLoss.divide(investedAmount, 4, RoundingMode.HALF_UP)
+                    .multiply(new BigDecimal("100"));
+        }
+
+        // then
+        assertThat(result).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("수익률 계산: 복잡한 소수점 결과도 반올림 정책에 따라 정확해야 한다")
+    void calculateYield_with_rounding() {
+        // given
+        // 손익: 1,000원, 투자 원가: 30,000원
+        // (1,000 / 30,000) * 100 = 3.333333...
+        BigDecimal profitLoss = new BigDecimal("1000");
+        BigDecimal investedAmount = new BigDecimal("30000");
+
+        // when
+        BigDecimal result = profitLoss.divide(investedAmount, 4, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"));
+
+        // then
+        // 0.0333 * 100 = 3.3300
+        assertThat(result).isEqualByComparingTo("3.33");
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 주식 거래 지표(보유 수량, 평단가, 수익률) 계산 API 구현

---

## 작업 개요

주식 거래 로그(`TradeLog`)를 기반으로 특정 티커에 대한 사용자의 보유 현황 및 수익률을 계산하여 반환하는 기능을 구현했습니다.

---

## 작업 내용

### 1. 도메인 모델(`TradeMetrics`) 중심의 로직 설계
- **도메인 계층 이동**: 단순 데이터 전달용 DTO였던 `TradeMetricsDto`를 비즈니스 로직을 포함한 도메인 객체 `TradeMetrics`로 격상하여 `domain` 패키지로 이동했습니다.
- **로직 캡슐화**: 평가 금액, 투자 원가, 손익, 수익률 계산 공식을 각각의 `private` 메서드로 분리하여 응집도를 높였습니다.
  - `calculateEvaluationAmount`: 현재가 × 보유 수량
  - `calculateInvestedAmount`: 평단가 × 보유 수량
  - `calculateYield`: (손익 / 원가) × 100

### 2. 출력 포맷 개선 및 지수 표기법(E+n) 해결
- **Response 타입 변경**: `TradeMetricsResponse`의 필드 타입을 `BigDecimal`에서 `String`으로 변경하여 프론트엔드에서의 데이터 처리 안정성을 높였습니다.
- **포맷팅 적용**: `stripTrailingZeros().toPlainString()`을 사용하여 `1.001E+5`와 같은 지수 표기법을 `100100`과 같은 직관적인 숫자로 강제 변환했습니다.
- **수익률 정밀도**: 수익률(`yield`)은 소수점 2자리에서 반올림(`HALF_UP`)하여 일관된 형식을 유지합니다.

### 3. 예외 처리 및 검증 로직
- `tickerRepository.existsById()`를 통해 존재하지 않는 티커에 대한 요청을 사전에 차단 (`TickerNotFoundException`).
- 보유 수량이 0 이하인 경우 불필요한 계산을 방지하기 위해 `TradeMetricsResponse.empty()` 반환 로직을 적용했습니다.

### 4. 단위 테스트(Unit Test)를 통한 로직 검증
- **도메인 로직 검증**: `TradeMetrics` 내 각 계산 메서드(`평가금액`, `투자원가`, `손익`, `수익률`)에 대한 단위 테스트를 수행했습니다.
- **엣지 케이스 처리**:
  - 투자 원가가 0인 경우(보유 수량 없음) `DivideByZero` 예외 방지 로직 검증
  - 손실이 발생한 경우 마이너스 수익률 정상 산출 검증
  - 소수점 단위 수량 및 가격 계산 시 정밀도 유지 확인
- **포맷팅 검증**: 최종 응답 시 지수 표기법(`E+n`) 제거 및 불필요한 0 제거(`stripTrailingZeros`) 여부를 확인했습니다.
---
