### PR TITLE
feat: 차트 위 포인트 내역 API 구현

### DIFF
--- a/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
+++ b/src/main/java/com/joojoo/api/block/domain/repository/BlockRepository.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.block.domain.repository;
 
 import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 import com.joojoo.api.user.domain.model.entity.User;
 
 import java.util.List;
@@ -32,4 +33,7 @@ public interface BlockRepository {
     Optional<Block> findByIdWithChildren(Long blockId);
 
     void deleteAllBlockMappings(Long userId);
+
+    /** 사용자가 작성한 블럭에 포함된 티커 관련 정보 조회 */
+    List<ChartOverlayResponse.AnalysisBlockDto> findByUserIdAndTickerId(Long userId, Long tickerId);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/persistence/BlockRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/persistence/BlockRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.block.infrastructure.queryDsl.BlockQueryDslRepository;
 import com.joojoo.api.block.infrastructure.rdbms.BlockJpaRepository;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.global.exception.handleException.block.BlockNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -79,6 +80,11 @@ public class BlockRepositoryImpl implements BlockRepository {
     @Override
     public void deleteAllBlockMappings(Long userId) {
         blockQueryDslRepository.deleteAllBlockMappings(userId);
+    }
+
+    @Override
+    public List<ChartOverlayResponse.AnalysisBlockDto> findByUserIdAndTickerId(Long userId, Long tickerId) {
+        return blockQueryDslRepository.findByUserIdAndTickerId(userId, tickerId);
     }
 
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepository.java
@@ -1,6 +1,7 @@
 package com.joojoo.api.block.infrastructure.queryDsl;
 
 import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -11,4 +12,6 @@ public interface BlockQueryDslRepository {
     Map<Long, Long> getChildCounts(List<Long> rootIds);
 
     void deleteAllBlockMappings(Long userId);
+
+    List<ChartOverlayResponse.AnalysisBlockDto> findByUserIdAndTickerId(Long userId, Long tickerId);
 }

--- a/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/block/infrastructure/queryDsl/BlockQueryDslRepositoryImpl.java
@@ -4,8 +4,10 @@ import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.domain.model.entity.QBlock;
 import com.joojoo.api.blockTag.domain.model.entity.QBlockTag;
 import com.joojoo.api.blockTicker.domain.model.entity.QBlockTicker;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -72,6 +74,25 @@ public class BlockQueryDslRepositoryImpl implements BlockQueryDslRepository {
                 .delete(block)
                 .where(block.user.id.eq(userId))
                 .execute();
+    }
+
+    @Override
+    public List<ChartOverlayResponse.AnalysisBlockDto> findByUserIdAndTickerId(Long userId, Long tickerId) {
+        return queryFactory
+                .select(Projections.constructor(ChartOverlayResponse.AnalysisBlockDto.class,
+                        block.id,
+                        block.content,
+                        block.createdAt
+                ))
+                .from(block)
+                .distinct()
+                .join(blockTicker).on(blockTicker.block.id.eq(block.id))
+                .where(
+                        block.user.id.eq(userId),
+                        blockTicker.ticker.id.eq(tickerId),
+                        block.isDeleted.isFalse()
+                )
+                .fetch();
     }
 
     /** 부모ID 가 있는 자식 블록 ID만 조회합니다. */

--- a/src/main/java/com/joojoo/api/tradeLog/application/port/in/GetTraderLogUseCase.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/port/in/GetTraderLogUseCase.java
@@ -1,8 +1,11 @@
 package com.joojoo.api.tradeLog.application.port.in;
 
 import com.joojoo.api.tradeLog.presentation.dto.request.calculate.TradeCalculateRequest;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
 
 public interface GetTraderLogUseCase {
     TradeMetricsResponse getTradeLogCalculate(Long userId, TradeCalculateRequest tradeCalculateRequest);
+
+    ChartOverlayResponse getTradeLogChart(Long userId, Long tickerId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/application/service/query/QueryTraderLogService.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/service/query/QueryTraderLogService.java
@@ -1,23 +1,29 @@
 package com.joojoo.api.tradeLog.application.service.query;
 
+import com.joojoo.api.block.domain.repository.BlockRepository;
 import com.joojoo.api.ticker.domain.repository.TickerRepository;
 import com.joojoo.api.tradeLog.application.port.in.GetTraderLogUseCase;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
-import com.joojoo.api.tradeLog.presentation.dto.request.calculate.TradeCalculateRequest;
 import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
+import com.joojoo.api.tradeLog.presentation.dto.request.calculate.TradeCalculateRequest;
 import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 import com.joojoo.global.exception.handleException.tickers.TickerNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class QueryTraderLogService implements GetTraderLogUseCase {
 
     private final TradeLogRepository tradeLogRepository;
     private final TickerRepository tickerRepository;
+    private final BlockRepository blockRepository;
 
     @Override
     public TradeMetricsResponse getTradeLogCalculate(Long userId, TradeCalculateRequest tradeCalculateRequest) {
@@ -31,6 +37,18 @@ public class QueryTraderLogService implements GetTraderLogUseCase {
         }
 
         return metrics.calculate(tradeCalculateRequest.getCurrentPrice());
+    }
+
+    @Override
+    public ChartOverlayResponse getTradeLogChart(Long userId, Long tickerId) {
+        if(!tickerRepository.existsById(tickerId)){
+            throw new TickerNotFoundException();
+        }
+
+        List<ChartOverlayResponse.TradeDetailDto> logs = tradeLogRepository.getTradeBuySellRecords(userId, tickerId);
+        List<ChartOverlayResponse.AnalysisBlockDto> blocks = blockRepository.findByUserIdAndTickerId(userId, tickerId);
+
+        return ChartOverlayResponse.of(logs, blocks);
     }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/domain/repository/TradeLogRepository.java
@@ -2,6 +2,9 @@ package com.joojoo.api.tradeLog.domain.repository;
 
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
+
+import java.util.List;
 
 public interface TradeLogRepository {
     /** TradeLog 저장 */
@@ -18,4 +21,7 @@ public interface TradeLogRepository {
 
     /** 사용자가 특정 종목을 매수한 기록을 조회 */
     TradeMetrics findAllBuyLogsByTicker(Long userId, Long tickerId);
+
+    /** 사용자가 특정 종목의 매수, 매도 거래 내역 조회 */
+    List<ChartOverlayResponse.TradeDetailDto> getTradeBuySellRecords(Long userId, Long tickerId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepository.java
@@ -1,6 +1,9 @@
 package com.joojoo.api.tradeLog.infrastructure.queryDsl;
 
 import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
+
+import java.util.List;
 
 public interface tradeLogQueryDslRepository {
     void withdrawByUserId(Long userId);
@@ -8,4 +11,6 @@ public interface tradeLogQueryDslRepository {
     void deleteByTradeLogId(Long userId, Long tradeLogId);
 
     TradeMetrics findAllBuyLogsByTicker(Long userId, Long tickerId);
+
+    List<ChartOverlayResponse.TradeDetailDto> getTradeBuySellRecords(Long userId, Long tickerId);
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/queryDsl/tradeLogQueryDslRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.joojoo.api.tradeLog.infrastructure.queryDsl;
 import com.joojoo.api.common.domain.enums.TradeType;
 import com.joojoo.api.tradeLog.domain.model.entity.QTradeLog;
 import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -67,6 +69,23 @@ public class tradeLogQueryDslRepositoryImpl implements tradeLogQueryDslRepositor
                         tradeLog.ticker.id.eq(tickerId)
                 )
                 .fetchOne();
+    }
+
+    @Override
+    public List<ChartOverlayResponse.TradeDetailDto> getTradeBuySellRecords(Long userId, Long tickerId) {
+        return queryFactory
+                .select(Projections.constructor(ChartOverlayResponse.TradeDetailDto.class,
+                        tradeLog.id,
+                        tradeLog.executedAt,
+                        tradeLog.tradeType
+                ))
+                .from(tradeLog)
+                .where(
+                        tradeLog.user.id.eq(userId),
+                        tradeLog.ticker.id.eq(tickerId),
+                        tradeLog.isDeleted.isFalse()
+                )
+                .fetch();
     }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/tradeLog/infrastructure/rdbms/TradeLogRepositoryImpl.java
@@ -4,11 +4,14 @@ import com.joojoo.api.blockTag.domain.repository.BlockTagRepository;
 import com.joojoo.api.blockTicker.domain.repository.BlockTickerRepository;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
-import com.joojoo.api.tradeLog.infrastructure.queryDsl.tradeLogQueryDslRepository;
 import com.joojoo.api.tradeLog.domain.service.calculate.TradeMetrics;
+import com.joojoo.api.tradeLog.infrastructure.queryDsl.tradeLogQueryDslRepository;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 import com.joojoo.global.exception.handleException.tradeLog.TradeLogNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -45,6 +48,11 @@ public class TradeLogRepositoryImpl implements TradeLogRepository {
     @Override
     public TradeMetrics findAllBuyLogsByTicker(Long userId, Long tickerId) {
         return tradeLogQueryDslRepository.findAllBuyLogsByTicker(userId, tickerId);
+    }
+
+    @Override
+    public List<ChartOverlayResponse.TradeDetailDto> getTradeBuySellRecords(Long userId, Long tickerId) {
+        return tradeLogQueryDslRepository.getTradeBuySellRecords(userId, tickerId);
     }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/presentation/controller/TradeLogController.java
+++ b/src/main/java/com/joojoo/api/tradeLog/presentation/controller/TradeLogController.java
@@ -9,6 +9,7 @@ import com.joojoo.api.tradeLog.application.port.in.GetTraderLogUseCase;
 import com.joojoo.api.tradeLog.presentation.dto.request.TradeRequestDto;
 import com.joojoo.api.tradeLog.presentation.dto.request.calculate.TradeCalculateRequest;
 import com.joojoo.api.tradeLog.presentation.dto.response.calculate.TradeMetricsResponse;
+import com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay.ChartOverlayResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -98,6 +99,27 @@ public class TradeLogController {
             @Valid @RequestBody TradeCalculateRequest tradeCalculateRequest
             ) {
         return BaseResponse.ok(getTraderLogUseCase.getTradeLogCalculate(user.getUserId(), tradeCalculateRequest));
+    }
+
+    @Operation(summary = "차트 위 포인트 내역 API", description = "차트 위 포인트 내역 API입니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ChartOverlayResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 매매일지를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/chart/{tickerId}")
+    public BaseResponse<ChartOverlayResponse> getTradeLogChart(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long tickerId
+    ) {
+        return BaseResponse.ok(getTraderLogUseCase.getTradeLogChart(user.getUserId(), tickerId));
     }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/presentation/dto/response/chartOverlay/ChartOverlayResponse.java
+++ b/src/main/java/com/joojoo/api/tradeLog/presentation/dto/response/chartOverlay/ChartOverlayResponse.java
@@ -1,0 +1,72 @@
+package com.joojoo.api.tradeLog.presentation.dto.response.chartOverlay;
+
+import com.joojoo.api.common.domain.enums.TradeType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChartOverlayResponse {
+
+    private List<TradeDetailDto> buyLogs;  // 매수 기록 리스트
+    private List<TradeDetailDto> sellLogs; // 매도 기록 리스트
+    private List<AnalysisBlockDto> analysisBlocks; // 블록(분석) 리스트
+
+    @Builder
+    public ChartOverlayResponse(List<TradeDetailDto> buyLogs,
+                                List<TradeDetailDto> sellLogs,
+                                List<AnalysisBlockDto> analysisBlocks) {
+        this.buyLogs = buyLogs;
+        this.sellLogs = sellLogs;
+        this.analysisBlocks = analysisBlocks;
+    }
+
+    public static ChartOverlayResponse of(List<TradeDetailDto> logs, List<AnalysisBlockDto> blocks) {
+        return ChartOverlayResponse.builder()
+                .buyLogs(filterByTradeType(logs, TradeType.BUY))
+                .sellLogs(filterByTradeType(logs, TradeType.SELL))
+                .analysisBlocks(blocks)
+                .build();
+    }
+
+    private static List<TradeDetailDto> filterByTradeType(List<TradeDetailDto> logs, TradeType type) {
+        return logs.stream()
+                .filter(log -> log.getTradeType() == type)
+                .toList();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class TradeDetailDto {
+        private Long id;
+        private LocalDateTime executedAt; // 매매 시간
+        private TradeType tradeType;
+
+        @Builder
+        public TradeDetailDto(Long id, LocalDateTime executedAt, TradeType tradeType) {
+            this.id = id;
+            this.executedAt = executedAt;
+            this.tradeType = tradeType;
+        }
+
+        public static TradeDetailDto from(TradeDetailDto entity) {
+            return TradeDetailDto.builder()
+                    .id(entity.getId())
+                    .executedAt(entity.getExecutedAt())
+                    .tradeType(entity.getTradeType())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AnalysisBlockDto {
+        private Long id;
+        private String content;
+        private LocalDateTime createdAt;
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feat] 차트 오버레이 매매 기록 및 분석 블록 조회 기능 구현

---

## 작업 개요

사용자가 특정 티커의 차트를 볼 때, 과거 매매 내역(매수/매도 포인트)과 해당 시점에 작성했던 분석 블록(메모)을 타임라인에 맞춰 한눈에 확인할 수 있도록 데이터를 제공합니다.

---

## 작업 내용

### 1. Querydsl Projections를 통한 성능 최적화
- `TradeLog`와 `Block` 엔티티 전체를 조회하는 대신, 필요한 필드만 선택적으로 조회하여 메모리 낭비를 줄였습니다.
- `block_tickers` 테이블 조인 시 발생하는 중복 데이터 문제를 `distinct()` 처리를 통해 해결했습니다.

### 2. DTO 중심의 캡슐화 및 책임 분리
- **ChartOverlayResponse**: 서비스 레이어의 가공 로직을 DTO 내부(`of`, `filterByTradeType`)로 옮겨 캡슐화했습니다.
- **TradeDetailDto**: 매매 타입(`Enum`)을 안전하게 처리하며, 차트 표시를 위한 최소한의 데이터(ID, 시간, 타입)만 포함합니다.

### 3. 도메인 간 데이터 통합
- 서로 다른 도메인인 `trade_logs`와 `blocks` 데이터를 하나의 응답 객체로 통합하여 프런트엔드에서 차트 라이브러리 연동을 용이하게 했습니다.

---