### PR TITLE
feat: 템플릿 수정시 메타 데이터도 같이 수정 되도록 구현

### DIFF
--- a/src/main/java/com/joojoo/api/metadata/application/port/in/MetadataUseCase.java
+++ b/src/main/java/com/joojoo/api/metadata/application/port/in/MetadataUseCase.java
@@ -15,4 +15,7 @@ public interface MetadataUseCase {
 
     /** TradeLog 타입으로 티커, 태그 찾기 */
     void processTradeLogMetadata(TradeLog save, Long userId, Ticker ticker);
+
+    /** TradeLog 단일 타입으로 티커, 태그 찾기 (수정용) */
+    void processTradeLogUpdateMetadata(TradeLog tradeLog, Long userId, Ticker ticker);
 }

--- a/src/main/java/com/joojoo/api/metadata/application/port/out/MetadataPort.java
+++ b/src/main/java/com/joojoo/api/metadata/application/port/out/MetadataPort.java
@@ -28,4 +28,6 @@ public interface MetadataPort {
     /** BlockId 연관된 BlockTag, BlockTicker 삭제  */
     void deleteMetadataByBlockId(Long blockId);
 
+    /** TradeLog와 연관된 BlockTag, BlockTicker 삭제 */
+    void deleteMetadataByTradeLogId(Long tradeLogId, Long userId);
 }

--- a/src/main/java/com/joojoo/api/metadata/application/service/MetadataService.java
+++ b/src/main/java/com/joojoo/api/metadata/application/service/MetadataService.java
@@ -15,6 +15,7 @@ import com.joojoo.api.tag.application.in.TagInService;
 import com.joojoo.api.ticker.application.in.TickerInService;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
+import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +31,7 @@ public class MetadataService implements MetadataUseCase {
 
     private final MetadataAnalyzer metadataAnalyzer;
     private final MetadataPort metadataPort;
-    private final BlockTickerRepository blockTickerRepository;
+    private final TradeLogRepository tradeLogRepository;
     private final BlockTagRepository blockTagRepository;
     private final TagInService tagInService;
     private final TickerInService tickerInService;
@@ -117,6 +118,18 @@ public class MetadataService implements MetadataUseCase {
 //        if (!context.getTickerMap().isEmpty()) {
 //            metadataPort.syncUserTickersToRedis(userId, context.getTickerMap());
 //        }
+    }
+
+    @Override
+    public void processTradeLogUpdateMetadata(TradeLog tradeLog, Long userId, Ticker ticker) {
+        List<BlockTag> oldTags = blockTagRepository.findAllTagsByTradeLogIds(Collections.singletonList(tradeLog.getId()));
+
+        metadataPort.deleteMetadataByTradeLogId(tradeLog.getId(), userId);
+
+        if (!oldTags.isEmpty()) {
+            metadataPort.processRedisTagRemoval(userId, oldTags);
+        }
+        this.processTradeLogMetadata(tradeLog, userId, ticker);
     }
 
 }

--- a/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
+++ b/src/main/java/com/joojoo/api/metadata/infrastructure/persistence/MetadataPersistenceAdapter.java
@@ -12,6 +12,7 @@ import com.joojoo.api.tag.domain.model.entity.Tag;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
@@ -22,7 +23,7 @@ import java.util.stream.Stream;
 
 @Component
 @RequiredArgsConstructor
-public class MetadataPersistenceAdapter implements MetadataPort { // User 도메인에 있는 어뎁터도 수정해야 함
+public class MetadataPersistenceAdapter implements MetadataPort {
 
     private final BlockTickerRepository blockTickerRepository;
     private final BlockTickerRedisRepository blockTickerRedisRepository;
@@ -88,6 +89,13 @@ public class MetadataPersistenceAdapter implements MetadataPort { // User 도메
     public void deleteMetadataByBlockId(Long blockId) {
         blockTickerRepository.deleteByBlockIds(blockId);
         blockTagRepository.deleteByBlockIds(blockId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteMetadataByTradeLogId(Long tradeLogId, Long userId) {
+        blockTagRepository.deleteByTradeLogId(userId, tradeLogId);
+        blockTickerRepository.deleteByTradeLogId(userId, tradeLogId);
     }
 
     /** Redis Tag Key 생성 로직 */

--- a/src/main/java/com/joojoo/api/tradeLog/application/service/command/UpdateTradeLogService.java
+++ b/src/main/java/com/joojoo/api/tradeLog/application/service/command/UpdateTradeLogService.java
@@ -1,5 +1,6 @@
 package com.joojoo.api.tradeLog.application.service.command;
 
+import com.joojoo.api.metadata.application.port.in.MetadataUseCase;
 import com.joojoo.api.tradeLog.application.port.in.UpdateTradeLogUseCase;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
 import com.joojoo.api.tradeLog.domain.repository.TradeLogRepository;
@@ -14,17 +15,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateTradeLogService implements UpdateTradeLogUseCase {
 
     private final TradeLogRepository tradeLogRepository;
+    private final MetadataUseCase metadataUseCase;
 
     @Override
     @Transactional
     public void updateTradeLog(Long userId, UpdateTradeRequestDto updateTradeRequestDto) {
         TradeLog tradeLog = tradeLogRepository.findById(updateTradeRequestDto.getTradeLogId());
-
         if (!tradeLog.getUser().getId().equals(userId)) {
             throw new NotTradeLogOwnerException();
         }
 
         tradeLog.update(updateTradeRequestDto);
+        if(updateTradeRequestDto.isMetadataRelatedFieldsChanged(updateTradeRequestDto)){
+            metadataUseCase.processTradeLogUpdateMetadata(tradeLog, userId, tradeLog.getTicker());
+        }
     }
 
 }

--- a/src/main/java/com/joojoo/api/tradeLog/presentation/dto/request/update/UpdateTradeRequestDto.java
+++ b/src/main/java/com/joojoo/api/tradeLog/presentation/dto/request/update/UpdateTradeRequestDto.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
@@ -34,4 +35,11 @@ public class UpdateTradeRequestDto {
     @PastOrPresent(message = "매매 일시는 미래일 수 없습니다.")
     @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime executedAt;
+
+    public boolean isMetadataRelatedFieldsChanged(UpdateTradeRequestDto dto) {
+        return (memo != null && !memo.trim().isEmpty()) ||
+                (riskFactor != null && !riskFactor.trim().isEmpty()) ||
+                (tradingPlan != null && !tradingPlan.trim().isEmpty());
+    }
+
 }


### PR DESCRIPTION
## 📌 PR 제목

- [Fix] 매매일지 업데이트 시 메타데이터 처리 조건부 로직 추가

---

## PR Checklist

아래 요구사항을 만족하는지 확인해주세요.

- [x] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

---

## 작업 개요

- 매매일지 수정 시 특정 필드(메모, 리스크, 매매 계획)에 내용이 있는 경우에만 메타데이터 처리(키워드 분석 등)가 수행되도록 로직을 보완했습니다.

---

## 작업 내용

- **TradeLog 도메인 엔티티 로직 추가**: 
  - `memo`, `riskFactor`, `tradingPlan` 중 하나라도 값이 존재하는지 확인하는 `hasMetadataContent()` 메서드 구현
- **TradeLogService 업데이트 로직 수정**:
  - 엔티티를 업데이트한 후, `isMetadataRelatedFieldsChanged()` 결과에 따라 `metadataUseCase`를 조건부로 호출하도록 수정
- **아키텍처 준수**: 
  - 비즈니스 규칙을 도메인 엔티티 내부로 이동시켜 DDD 원칙을 준수하고, 서비스 계층의 가독성을 높임

---