### PR TITLE
test: `BlockValidator` 테스트 코드 작성

### DIFF
--- a/src/main/java/com/joojoo/api/block/presentation/dto/request/createBlock/BlockRequestDto.java
+++ b/src/main/java/com/joojoo/api/block/presentation/dto/request/createBlock/BlockRequestDto.java
@@ -1,10 +1,13 @@
 package com.joojoo.api.block.presentation.dto.request.createBlock;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@Builder
 @Getter
 @AllArgsConstructor
 public class BlockRequestDto {

--- a/src/test/java/com/joojoo/api/block/domain/service/validation/BlockValidatorTest.java
+++ b/src/test/java/com/joojoo/api/block/domain/service/validation/BlockValidatorTest.java
@@ -1,0 +1,149 @@
+package com.joojoo.api.block.domain.service.validation;
+
+import com.joojoo.api.block.domain.model.entity.Block;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockRequestDto;
+import com.joojoo.api.block.presentation.dto.request.createBlock.BlockSaveRequestDto;
+import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.global.exception.enums.ErrorCode;
+import com.joojoo.global.exception.handleException.block.BlockOwnerMismatchException;
+import com.joojoo.global.exception.handleException.block.BlockPromotionLimitExceededException;
+import com.joojoo.global.exception.handleException.block.InvalidBlockStructureException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BlockValidatorTest {
+
+    private final BlockValidator blockValidator = new BlockValidator();
+
+    @Nested
+    @DisplayName("validateStructure 테스트")
+    class ValidateStructureTest {
+
+        private BlockRequestDto createBlock(int depth, List<BlockRequestDto> children) {
+            return BlockRequestDto.builder()
+                    .depth(depth)
+                    .children(children)
+                    .content("테스트 블록")
+                    .isSaved(false)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("성공: 루트 블록이 1개이고 최대 깊이(2)를 넘지 않음")
+        void success_validStructure() {
+            // Given: Depth 0 -> Depth 1 -> Depth 2 구조
+            BlockRequestDto depth2 = createBlock(2, null);
+            BlockRequestDto depth1 = createBlock(1, List.of(depth2));
+            BlockRequestDto root = createBlock(0, List.of(depth1));
+
+            BlockSaveRequestDto request = new BlockSaveRequestDto(List.of(root));
+
+            // When & Then
+            assertDoesNotThrow(() -> blockValidator.validateStructure(request));
+        }
+
+        @Test
+        @DisplayName("실패: 최대 깊이(2)를 초과하는 경우 (Depth 3 존재)")
+        void fail_exceedMaxDepth() {
+            // Given: Depth 0 -> 1 -> 2 -> 3
+            // validator 로직상 currentDepth가 2일 때 자식이 있으면 예외가 발생합니다.
+            BlockRequestDto depth3 = createBlock(3, null);
+            BlockRequestDto depth2 = createBlock(2, List.of(depth3));
+            BlockRequestDto depth1 = createBlock(1, List.of(depth2));
+            BlockRequestDto root = createBlock(0, List.of(depth1));
+
+            BlockSaveRequestDto request = new BlockSaveRequestDto(List.of(root));
+
+            // When & Then
+            InvalidBlockStructureException exception = assertThrows(InvalidBlockStructureException.class,
+                    () -> blockValidator.validateStructure(request));
+
+            assertEquals(ErrorCode.MAX_BLOCK_DEPTH_EXCEEDED, exception.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("실패: 루트 블록이 없거나 여러 개인 경우")
+        void fail_invalidRootCount() {
+            BlockSaveRequestDto emptyRequest = new BlockSaveRequestDto(List.of());
+            assertThrows(InvalidBlockStructureException.class,
+                    () -> blockValidator.validateStructure(emptyRequest));
+        }
+    }
+
+    @Nested
+    @DisplayName("validateOwner 테스트")
+    class ValidateOwnerTest {
+
+        @Test
+        @DisplayName("성공: 블록 소유자와 요청자가 일치")
+        void success_ownerMatch() {
+            Long userId = 1L;
+            Block block = mock(Block.class);
+            User user = mock(User.class);
+
+            when(block.getUser()).thenReturn(user);
+            when(user.getId()).thenReturn(userId);
+
+            assertDoesNotThrow(() -> blockValidator.validateOwner(block, userId));
+        }
+
+        @Test
+        @DisplayName("실패: 블록 소유자가 다름")
+        void fail_ownerMismatch() {
+            Long userId = 1L;
+            Long otherUserId = 2L;
+            Block block = mock(Block.class);
+            User user = mock(User.class);
+
+            when(block.getUser()).thenReturn(user);
+            when(user.getId()).thenReturn(otherUserId);
+
+            assertThrows(BlockOwnerMismatchException.class,
+                    () -> blockValidator.validateOwner(block, userId));
+        }
+    }
+
+    @Nested
+    @DisplayName("validatePromotionLimit 테스트")
+    class ValidatePromotionLimitTest {
+
+        @Test
+        @DisplayName("성공: 자식이 승격되어도 부모의 자식 수가 3개 이하")
+        void success_withinPromotionLimit() {
+            // Given: 부모에게 2개의 자식이 있고(대상 포함), 대상 블록에 2개의 자식이 있는 경우
+            // (2-1) + 2 = 3 (통과)
+            Block parent = mock(Block.class);
+            Block targetBlock = mock(Block.class);
+
+            when(targetBlock.getDepth()).thenReturn(1);
+            when(parent.getChildren()).thenReturn(List.of(targetBlock, mock(Block.class)));
+            when(targetBlock.getChildren()).thenReturn(List.of(mock(Block.class), mock(Block.class)));
+
+            assertDoesNotThrow(() -> blockValidator.validatePromotionLimit(targetBlock, parent));
+        }
+
+        @Test
+        @DisplayName("실패: 승격 후 형제 수가 3개를 초과")
+        void fail_exceedPromotionLimit() {
+            // Given: 부모에게 2개의 자식이 있고, 대상 블록에 3개의 자식이 있는 경우
+            // (2-1) + 3 = 4 (실패)
+            Block parent = mock(Block.class);
+            Block targetBlock = mock(Block.class);
+
+            when(targetBlock.getDepth()).thenReturn(1);
+            when(parent.getChildren()).thenReturn(List.of(targetBlock, mock(Block.class)));
+            when(targetBlock.getChildren()).thenReturn(List.of(mock(Block.class), mock(Block.class), mock(Block.class)));
+
+            assertThrows(BlockPromotionLimitExceededException.class,
+                    () -> blockValidator.validatePromotionLimit(targetBlock, parent));
+        }
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Test] BlockValidator 단위 테스트 구현 및 객체 캡슐화 개선
---

## 작업 개요

블록 트리 구조의 유효성을 검증하는 `BlockValidator`의 단위 테스트를 작성하였습니다. 테스트의 신뢰성을 높이기 위해 Mock 위주의 테스트에서 실제 엔티티 객체 기반의 상태 검증 방식으로 개선하였으며, 관련 DTO의 캡슐화를 강화했습니다.

---

## 작업 내용

### 1. BlockValidator 단위 테스트 작성
- **`validateStructure` (트리 깊이 검증)**
  - 루트 블록이 1개인 정상 케이스 검증
  - 서비스 요구사항인 최대 깊이(MAX_DEPTH = 2)를 초과하는 트리 구조에 대한 예외 처리 검증
- **`validatePromotionLimit` (자식 승격 제한 검증)**
  - 특정 블록 삭제 시 자식들이 부모 레벨로 승격되는 시나리오 테스트
  - 승격 후 부모의 총 자식 수가 3개를 초과할 경우 `BlockPromotionLimitExceededException` 발생 여부 확인
- **`validateOwner` (권한 검증)**
  - 블록 소유자와 요청 사용자 ID 일치 여부 확인

### 2. 코드 품질 개선 및 캡슐화
- **DTO 개선**: `BlockRequestDto`의 Setter를 제거하고 `@Builder` 패턴을 도입하여 데이터 불변성 및 생성 시점의 일관성 확보
- **상태 기반 테스트**: `Mockito.when()`을 통한 행위 검증보다 실제 엔티티 간 연관 관계를 맺어 로직을 실행하는 상태 기반 테스트 수행

---
