### PR TITLE
Feature/add usa redis

### DIFF
--- a/src/main/java/com/joojoo/api/common/search/SearchRangeFactory.java
+++ b/src/main/java/com/joojoo/api/common/search/SearchRangeFactory.java
@@ -13,7 +13,7 @@ public class SearchRangeFactory {
     private static final String END_UNICODE = "\uffff";
 
     public SearchRange createSearchRange(String query) {
-        String converted = hangulConverter.jasoConvert(query);
+        String converted = hangulConverter.jasoConvert(query).toUpperCase();
         return buildRange(converted);
     }
 

--- a/src/main/java/com/joojoo/api/ticker/application/TickerService.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerService.java
@@ -2,7 +2,4 @@ package com.joojoo.api.ticker.application;
 
 public interface TickerService {
     void addStockToRedis(String name, String ticker);
-
-    // 운영 DB에 있는 주식을 Redis에 저장
-    void loadTickersToCache(Long userId);
 }

--- a/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
@@ -2,12 +2,13 @@ package com.joojoo.api.ticker.application;
 
 import com.joojoo.api.common.hangul.HangulConverter;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import com.joojoo.api.ticker.domain.model.enums.MarketType;
 import com.joojoo.api.ticker.domain.repository.TickerRedisRepository;
 import com.joojoo.api.ticker.domain.repository.TickerRepository;
+import com.joojoo.api.ticker.domain.service.SearchKeywordMapper;
 import com.joojoo.api.user.domain.model.entity.User;
 import com.joojoo.api.user.domain.repository.UserRepository;
 import com.joojoo.global.exception.handleException.tickers.InvalidTickerOrNameException;
-import com.joojoo.global.exception.handleException.users.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,7 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -30,6 +30,7 @@ public class TickerServiceImpl implements TickerService {
     private final TickerRepository tickerRepository;
     private final UserRepository userRepository;
     private final HangulConverter hangulConverter;
+    private final SearchKeywordMapper searchKeywordMapper;
 
     @Override
     public void addStockToRedis(String name, String ticker) {
@@ -44,32 +45,26 @@ public class TickerServiceImpl implements TickerService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void loadTickersToCache(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
+        User user = userRepository.getUserById(userId);
         user.validateAdminPermission();
 
-        List<Ticker> allStocks = tickerRepository.findAll();
-        Set<String> tickers = allStocks.stream()
-                .filter(ticker -> StringUtils.hasText(ticker.getName()) && StringUtils.hasText(ticker.getSymbol()))
-                .flatMap(this::generateSearchKeywords)
-                .collect(Collectors.toSet());
+        List<MarketType> targetMarkets = MarketType.getActiveMarkets();
+        for (MarketType market : targetMarkets) {
+            // 시장 별 데이터 조회
+            List<Ticker> stocks = tickerRepository.findByTickerMarket(market);
 
-        if (!tickers.isEmpty()) {
-            tickerRedisRepository.addStocksToRedis(tickers);
+            Set<String> searchIndexes = stocks.stream()
+                    .filter(s -> StringUtils.hasText(s.getName()) && StringUtils.hasText(s.getSymbol()))
+                    .flatMap(searchKeywordMapper::mapToSearchIndex) // Redis에 저장할 내용 생성
+                    .collect(Collectors.toSet());
+
+            if (!searchIndexes.isEmpty()) {
+                tickerRedisRepository.addStocksToRedis(searchIndexes);
+            }
+            log.info("{} 시장 캐시 업데이트 완료: {}건", market, searchIndexes.size());
         }
-        log.info("티커 Cache 업데이트 완료: {}건 처리됨", tickers.size());
-    }
-
-    private Stream<String> generateSearchKeywords(Ticker stock) {
-        String name = stock.getName();
-        String symbol = stock.getSymbol();
-        Long tickerId = stock.getId();
-
-        return Stream.of(
-                hangulConverter.jasoConvert(name) + "*" + name + "*" + symbol + "*" + tickerId,
-                hangulConverter.chosungConvert(name) + "*" + name + "*" + symbol + "*" + tickerId
-        );
     }
 
 }

--- a/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/application/TickerServiceImpl.java
@@ -1,13 +1,7 @@
 package com.joojoo.api.ticker.application;
 
 import com.joojoo.api.common.hangul.HangulConverter;
-import com.joojoo.api.ticker.domain.model.entity.Ticker;
-import com.joojoo.api.ticker.domain.model.enums.MarketType;
 import com.joojoo.api.ticker.domain.repository.TickerRedisRepository;
-import com.joojoo.api.ticker.domain.repository.TickerRepository;
-import com.joojoo.api.ticker.domain.service.SearchKeywordMapper;
-import com.joojoo.api.user.domain.model.entity.User;
-import com.joojoo.api.user.domain.repository.UserRepository;
 import com.joojoo.global.exception.handleException.tickers.InvalidTickerOrNameException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,9 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -27,10 +19,7 @@ import java.util.stream.Collectors;
 public class TickerServiceImpl implements TickerService {
 
     private final TickerRedisRepository tickerRedisRepository;
-    private final TickerRepository tickerRepository;
-    private final UserRepository userRepository;
     private final HangulConverter hangulConverter;
-    private final SearchKeywordMapper searchKeywordMapper;
 
     @Override
     public void addStockToRedis(String name, String ticker) {
@@ -42,29 +31,6 @@ public class TickerServiceImpl implements TickerService {
         tickers.add(hangulConverter.chosungConvert(name) + "*" + name + "*" + ticker);
 
         tickerRedisRepository.addStocksToRedis(tickers);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public void loadTickersToCache(Long userId) {
-        User user = userRepository.getUserById(userId);
-        user.validateAdminPermission();
-
-        List<MarketType> targetMarkets = MarketType.getActiveMarkets();
-        for (MarketType market : targetMarkets) {
-            // 시장 별 데이터 조회
-            List<Ticker> stocks = tickerRepository.findByTickerMarket(market);
-
-            Set<String> searchIndexes = stocks.stream()
-                    .filter(s -> StringUtils.hasText(s.getName()) && StringUtils.hasText(s.getSymbol()))
-                    .flatMap(searchKeywordMapper::mapToSearchIndex) // Redis에 저장할 내용 생성
-                    .collect(Collectors.toSet());
-
-            if (!searchIndexes.isEmpty()) {
-                tickerRedisRepository.addStocksToRedis(searchIndexes);
-            }
-            log.info("{} 시장 캐시 업데이트 완료: {}건", market, searchIndexes.size());
-        }
     }
 
 }

--- a/src/main/java/com/joojoo/api/ticker/application/port/in/CreateTIckerUseCase.java
+++ b/src/main/java/com/joojoo/api/ticker/application/port/in/CreateTIckerUseCase.java
@@ -10,4 +10,7 @@ public interface CreateTIckerUseCase {
     void initAmexTickerData();
 
     void initNyseTickerData();
+
+    /** 운영 DB에 있는 주식을 Redis에 저장 */
+    void loadTickersToCache(Long userId);
 }

--- a/src/main/java/com/joojoo/api/ticker/application/service/command/CreateTickerService.java
+++ b/src/main/java/com/joojoo/api/ticker/application/service/command/CreateTickerService.java
@@ -1,18 +1,25 @@
 package com.joojoo.api.ticker.application.service.command;
 
+import com.joojoo.api.common.hangul.HangulConverter;
 import com.joojoo.api.ticker.application.port.in.CreateTIckerUseCase;
 import com.joojoo.api.ticker.application.port.out.TickerDataProvider;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.ticker.domain.model.enums.MarketType;
+import com.joojoo.api.ticker.domain.repository.TickerRedisRepository;
 import com.joojoo.api.ticker.domain.repository.TickerRepository;
+import com.joojoo.api.ticker.domain.service.SearchKeywordMapper;
 import com.joojoo.api.ticker.presentation.dto.request.TickerDataDto;
+import com.joojoo.api.user.domain.model.entity.User;
+import com.joojoo.api.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -22,6 +29,9 @@ public class CreateTickerService implements CreateTIckerUseCase {
 
     private final TickerRepository tickerRepository;
     private final TickerDataProvider tickerDataProvider;
+    private final TickerRedisRepository tickerRedisRepository;
+    private final UserRepository userRepository;
+    private final SearchKeywordMapper searchKeywordMapper;
 
     @Override
     @Transactional
@@ -59,6 +69,29 @@ public class CreateTickerService implements CreateTIckerUseCase {
         processSynchronization(externalStocks, existingTickers);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public void loadTickersToCache(Long userId) {
+        User user = userRepository.getUserById(userId);
+        user.validateAdminPermission();
+
+        List<MarketType> targetMarkets = MarketType.getActiveMarkets();
+        for (MarketType market : targetMarkets) {
+            // 시장 별 데이터 조회
+            List<Ticker> stocks = tickerRepository.findByTickerMarket(market);
+
+            Set<String> searchIndexes = stocks.stream()
+                    .filter(s -> StringUtils.hasText(s.getName()) && StringUtils.hasText(s.getSymbol()))
+                    .flatMap(searchKeywordMapper::mapToSearchIndex) // Redis에 저장할 내용 생성
+                    .collect(Collectors.toSet());
+
+            if (!searchIndexes.isEmpty()) {
+                tickerRedisRepository.addStocksToRedis(searchIndexes);
+            }
+            log.info("{} 시장 캐시 업데이트 완료: {}건", market, searchIndexes.size());
+        }
+    }
+
     private void processSynchronization(List<TickerDataDto> externalStocks, List<Ticker> currentTickers) {
         Map<String, Ticker> tickerMap = currentTickers.stream()
                 .collect(Collectors.toMap(Ticker::getSymbol, t -> t));
@@ -67,7 +100,5 @@ public class CreateTickerService implements CreateTIckerUseCase {
         tickerRepository.saveAll(toSave);
         log.info("티커 데이터 업데이트 완료: {}건 처리됨", toSave.size());
     }
-
-
 
 }

--- a/src/main/java/com/joojoo/api/ticker/domain/model/entity/Ticker.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/model/entity/Ticker.java
@@ -2,7 +2,10 @@ package com.joojoo.api.ticker.domain.model.entity;
 
 import com.joojoo.api.ticker.domain.model.enums.MarketType;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/joojoo/api/ticker/domain/model/enums/MarketType.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/model/enums/MarketType.java
@@ -38,4 +38,13 @@ public enum MarketType {
     public static List<MarketType> koreaMarkets() {
         return List.of(KOSPI, KOSDAQ, KONEX, KOSDAQ_GLOBAL);
     }
+
+    /** 전체 시장 리스트 반환 */
+    public static List<MarketType> getActiveMarkets() {
+        return List.of(KOSPI, KOSDAQ, KONEX, KOSDAQ_GLOBAL, NASDAQ, NYSE, AMEX);
+    }
+
+    public boolean isKorea() {
+        return List.of(KOSPI, KOSDAQ, KONEX, KOSDAQ_GLOBAL).contains(this);
+    }
 }

--- a/src/main/java/com/joojoo/api/ticker/domain/service/SearchKeywordMapper.java
+++ b/src/main/java/com/joojoo/api/ticker/domain/service/SearchKeywordMapper.java
@@ -1,0 +1,46 @@
+package com.joojoo.api.ticker.domain.service;
+
+import com.joojoo.api.common.hangul.HangulConverter;
+import com.joojoo.api.ticker.domain.model.entity.Ticker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+public class SearchKeywordMapper {
+
+    private final HangulConverter hangulConverter;
+    private static final String DELIMITER = "*";
+
+    public Stream<String> mapToSearchIndex(Ticker stock) {
+        String name = stock.getName();
+        String symbol = stock.getSymbol();
+        Long id = stock.getId();
+
+        if (stock.getMarket().isKorea()) {
+            return createKoreaSearchIndex(name, symbol, id);
+        }
+        return createAmericaSearchIndex(name, symbol, id);
+    }
+
+    /** 한국 주식: 자소 및 초성 기반 인덱스 생성 */
+    private Stream<String> createKoreaSearchIndex(String name, String symbol, Long id) {
+        return Stream.of(
+                hangulConverter.jasoConvert(name) + DELIMITER + name + DELIMITER + symbol + DELIMITER + id,
+                hangulConverter.chosungConvert(name) + DELIMITER + name + DELIMITER + symbol + DELIMITER + id
+        );
+    }
+
+    /** 미국 주식: 대문자 변환 기반(명칭/심볼) 인덱스 생성 */
+    private Stream<String> createAmericaSearchIndex(String name, String symbol, Long id) {
+        String upperName = name.toUpperCase();
+        String upperSymbol = symbol.toUpperCase();
+
+        return Stream.of(
+                upperName + DELIMITER + name + DELIMITER + symbol + DELIMITER + id,
+                upperSymbol + DELIMITER + name + DELIMITER + symbol + DELIMITER + id
+        );
+    }
+}

--- a/src/main/java/com/joojoo/api/ticker/presentation/controller/TickerController.java
+++ b/src/main/java/com/joojoo/api/ticker/presentation/controller/TickerController.java
@@ -1,9 +1,9 @@
 package com.joojoo.api.ticker.presentation.controller;
 
-import com.joojoo.api.ticker.application.TickerService;
 import com.joojoo.api.common.domain.request.auth.CustomUserDetails;
 import com.joojoo.api.common.domain.response.BaseResponse;
 import com.joojoo.api.common.domain.response.ErrorResponse;
+import com.joojoo.api.ticker.application.TickerService;
 import com.joojoo.api.ticker.application.port.in.CreateTIckerUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -49,7 +49,7 @@ public class TickerController {
 
     @PostMapping("/load-Cache")
     public void dbToRedis(@AuthenticationPrincipal CustomUserDetails user){
-        tickerService.loadTickersToCache(user.getUserId());
+        createTIckerUseCase.loadTickersToCache(user.getUserId());
     }
 
 }


### PR DESCRIPTION
## 📌 PR 제목
- [Feat] 미국 시장(NASDAQ, NYSE, AMEX) 데이터 연동 및 Redis 검색 인덱싱 최적화

---

## 📝 작업 개요
기존 국내 주식 시장에 국한되었던 데이터를 미국 3대 거래소까지 확장하고, 수만 건의 데이터를 안정적으로 처리하기 위한 캐시 로딩 전략 및 DDD 기반의 리팩토링을 진행했습니다.

---

## 🚀 주요 작업 내용

### 1. 캐시 로딩 전략 개선 (Application Layer)
- **시장별 분할 처리**: `findAll()` 대신 시장별(`MarketType`)로 데이터를 순회 조회하여 서버 메모리 부하 방지
- **Read-Only 트랜잭션**: `@Transactional(readOnly = true)`를 적용하여 JPA 스냅샷 보관 및 변경 감지 오버헤드 제거

### 2. 검색 인덱싱 최적화 (Infrastructure Layer)
- **SearchKeywordMapper 도입**: Redis의 `rangeByLex` 검색에 최적화된 형태로 데이터 가공 로직 분리
- **다국어 특화 인덱싱**:
  - **한국**: 한글 자소 및 초성 분리 데이터 생성
  - **미국**: 종목명 및 심볼의 대문자 정규화를 통한 통합 검색 지원
- **데이터 명확화**: 가공된 데이터를 `searchIndexes`로 명명하여 '검색용 색인'임을 명시

### 3. DDD 기반 아키텍처 리팩토링
- **Domain**: `MarketType` 내부에 시장 판별 로직(isKorea) 캡슐화
- **Domain Service**: 시장별 검색 키워드 생성 정책을 SearchKeywordMapper로 책임 위임하여 Ticker 엔티티의 순수성 유지 및 비즈니스 로직 응집도 향상
- **Application**: 비즈니스 흐름(권한 체크, 시장 순회) 오케스트레이션

---