### PR TITLE
feat: 블럭 작성 시 Symbol을 작성을 해도 인식 할 수 있도록 수정

### DIFF
--- a/src/main/java/com/joojoo/api/metadata/application/service/MetadataService.java
+++ b/src/main/java/com/joojoo/api/metadata/application/service/MetadataService.java
@@ -54,7 +54,7 @@ public class MetadataService implements MetadataUseCase {
         // 도메인 엔티티 생성
         List<BlockTicker> bTickers = metadataAnalyzer.createBlockTickers(analysisMap, context, userId);
         List<BlockTag> bTags = metadataAnalyzer.createBlockTags(analysisMap, context, userId);
-        
+
         // 저장 및 동기화
         metadataPort.saveTickersAndTags(bTickers, bTags);
 

--- a/src/main/java/com/joojoo/api/metadata/domain/service/MetadataAnalyzer.java
+++ b/src/main/java/com/joojoo/api/metadata/domain/service/MetadataAnalyzer.java
@@ -4,11 +4,11 @@ import com.joojoo.api.block.domain.model.entity.Block;
 import com.joojoo.api.block.presentation.dto.request.metadata.MatchedMetadataDto;
 import com.joojoo.api.blockTag.domain.model.entity.BlockTag;
 import com.joojoo.api.blockTicker.domain.model.entity.BlockTicker;
+import com.joojoo.api.common.domain.enums.TagSourceType;
+import com.joojoo.api.metadata.domain.MetadataContext;
 import com.joojoo.api.tag.domain.model.entity.Tag;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.tradeLog.domain.model.entity.TradeLog;
-import com.joojoo.api.metadata.domain.MetadataContext;
-import com.joojoo.api.common.domain.enums.TagSourceType;
 import org.springframework.stereotype.Component;
 
 import java.util.*;

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/persistence/TickerRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/persistence/TickerRepositoryImpl.java
@@ -1,12 +1,12 @@
 package com.joojoo.api.ticker.infrastructure.persistence;
 
+import com.joojoo.api.common.domain.response.detail.count.RelatedBlockDetailCountResponse;
 import com.joojoo.api.ticker.application.port.in.TickerInService;
 import com.joojoo.api.ticker.domain.model.entity.Ticker;
 import com.joojoo.api.ticker.domain.model.enums.MarketType;
 import com.joojoo.api.ticker.domain.repository.TickerRepository;
 import com.joojoo.api.ticker.infrastructure.queryDsl.TickerQueryDslRepository;
 import com.joojoo.api.ticker.infrastructure.rdbms.TickerJpaRepository;
-import com.joojoo.api.common.domain.response.detail.count.RelatedBlockDetailCountResponse;
 import com.joojoo.global.exception.handleException.tickers.TickerNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -70,9 +69,17 @@ public class TickerRepositoryImpl implements
 
     @Override
     @Transactional(readOnly = true)
-    public Map<String, Ticker> getTickerMap(Set<String> names) {
-        if (names.isEmpty()) return Collections.emptyMap();
-        return tickerQueryDslRepository.findAllByTickerNames(names).stream()
-                .collect(Collectors.toMap(Ticker::getName, t -> t));
+    public Map<String, Ticker> getTickerMap(Set<String> identifiers) {
+        if (identifiers.isEmpty()) return Collections.emptyMap();
+
+        List<Ticker> tickers = tickerQueryDslRepository.findAllByTickerNames(identifiers);
+
+        Map<String, Ticker> resultMap = new HashMap<>();
+        for (Ticker t : tickers) {
+            resultMap.put(t.getName(), t);
+            resultMap.put(t.getSymbol(), t);
+        }
+        return resultMap;
     }
+
 }

--- a/src/main/java/com/joojoo/api/ticker/infrastructure/queryDsl/TickerQueryDslRepositoryImpl.java
+++ b/src/main/java/com/joojoo/api/ticker/infrastructure/queryDsl/TickerQueryDslRepositoryImpl.java
@@ -30,7 +30,8 @@ public class TickerQueryDslRepositoryImpl implements TickerQueryDslRepository {
 
         return queryFactory
                 .selectFrom(ticker)
-                .where(ticker.name.in(symbols))
+                .where(ticker.name.in(symbols)
+                        .or(ticker.symbol.in(symbols)))
                 .fetch();
     }
 


### PR DESCRIPTION
## 📌 PR 제목

- [Fix] 블록 메타데이터 추출 시 주식 심볼(Symbol) 인식 오류 및 NPE 수정

---

## 작업 개요

블록 콘텐츠 내에서 미국 주식 심볼(예: $AAPL, $BLUW)을 입력했을 때, 시스템이 이를 이름(Name)과 매칭하지 못해 발생하는 조회 오류 및 NullPointerException을 해결했습니다.

---

## 작업 내용

- **다중 식별자 매핑 로직 도입 (Dual-Key Mapping)**
  - `TickerInService.getTickerMap` 메서드 수정: 조회된 Ticker 엔티티를 Map에 저장할 때 `Name`과 `Symbol`을 모두 Key로 등록하여 어떤 식별자로도 엔티티 조회가 가능하도록 개선
  - 기존에 이름 기반으로만 찾던 `MetadataContext`의 조회 한계 극복

- **MetadataAnalyzer 정합성 및 안정성 강화**
  - `createBlockTickers` 메서드 내 Ticker 엔티티 존재 여부에 대한 방어 로직 추가
  - 로그 출력 시 발생하던 `NullPointerException` 방지 및 유효하지 않은 티커 입력 시 워닝 로그 기록

- **미국 주식 Cashtag($) 지원 최적화**
  - 공백이 포함된 미국 기업 이름 대신 짧고 명확한 심볼 기반의 태깅이 시스템에 정상 반영되도록 연동 확인

---