### PR TITLE
fix: 티커 최근 검색 기록 메서드 이름, 응답 값 이름 도메인에 맞게 수정

### DIFF
--- a/src/main/java/com/joojoo/api/blockTicker/presentation/controller/BlockTickerController.java
+++ b/src/main/java/com/joojoo/api/blockTicker/presentation/controller/BlockTickerController.java
@@ -83,7 +83,7 @@ public class BlockTickerController {
             )
     })
     @GetMapping("/recent")
-    public BaseResponse<RecentTickersResponse> getRecentTags(
+    public BaseResponse<RecentTickersResponse> getRecentTickers(
             @AuthenticationPrincipal CustomUserDetails user
     ){
         return BaseResponse.ok(getTickerUseCase.getRecentTickers(user.getUserId()));

--- a/src/main/java/com/joojoo/api/blockTicker/presentation/dto/response/recent/RecentTickersResponse.java
+++ b/src/main/java/com/joojoo/api/blockTicker/presentation/dto/response/recent/RecentTickersResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class RecentTickersResponse {
-    private List<RecentTickersDto> tags;
+    private List<RecentTickersDto> tickers;
 
     public static RecentTickersResponse of(List<RecentTickersDto> tickers) {
         return new RecentTickersResponse(tickers);


### PR DESCRIPTION
## 📌 PR 제목

- [Fix] 티커 최근 검색 기록 메서드 이름, 응답 값 이름 도메인에 맞게 수정

---

## 작업 개요

최근 티커 내용인데 응답 값에 `tickers` 가 아닌 `tags` 로 되어있에 도메인에 맞게 `tickers`로 수정

---
